### PR TITLE
Fixes issue 95 - 

### DIFF
--- a/SharpRepository.Repository/RepositoryBase.cs
+++ b/SharpRepository.Repository/RepositoryBase.cs
@@ -100,10 +100,10 @@ namespace SharpRepository.Repository
             set
             {
                 _cachingStrategy = value ?? new NoCachingStrategy<T, TKey>();
-
-                // make sure we keep the curent caching enabled status
-                var cachingEnabled = QueryManager == null || QueryManager.CacheEnabled;
-                QueryManager = new QueryManager<T, TKey>(_cachingStrategy) {CacheEnabled = cachingEnabled};
+				QueryManager = new QueryManager<T, TKey>(_cachingStrategy)
+				               {
+					               CacheEnabled = !(_cachingStrategy is NoCachingStrategy<T, TKey>)
+				               };
             }
         } 
 

--- a/SharpRepository.Tests/SharpRepository.Tests.csproj
+++ b/SharpRepository.Tests/SharpRepository.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Specifications\SpecificationTests.cs" />
     <Compile Include="Spikes\AzureTableSpikes.cs" />
     <Compile Include="Spikes\BatchSpike.cs" />
+    <Compile Include="Spikes\CacheEnabledSpike.cs" />
     <Compile Include="Spikes\CompoundKeySpikes.cs" />
     <Compile Include="Spikes\AzureBlobSpikes.cs" />
     <Compile Include="Spikes\DeleteByKeyConstaintSpike.cs" />

--- a/SharpRepository.Tests/Spikes/CacheEnabledSpike.cs
+++ b/SharpRepository.Tests/Spikes/CacheEnabledSpike.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using NUnit.Framework;
+using SharpRepository.InMemoryRepository;
+using SharpRepository.Repository.Caching;
+using SharpRepository.Tests.TestObjects;
+using Should;
+
+namespace SharpRepository.Tests.Spikes
+{
+	[TestFixture]
+	public class CacheEnabledSpike : TestBase
+	{
+		[Test]
+		public void CachingEnabled_Should_Be_False_With_NoCachingStrategy()
+		{
+			var repository = new InMemoryRepository<Contact, Int32>(new NoCachingStrategy<Contact, int>());
+			repository.CachingEnabled.ShouldBeFalse();
+		}
+
+		[Test]
+		public void CachingEnabled_Should_Be_True_With_TimeoutCachingStrategy()
+		{
+			var repository = new InMemoryRepository<Contact, Int32>(new TimeoutCachingStrategy<Contact, int>(60));
+			repository.CachingEnabled.ShouldBeTrue();
+		}
+
+		[Test]
+		public void CachingEnabled_Should_Be_True_With_StandardCachingStrategy()
+		{
+			var repository = new InMemoryRepository<Contact, Int32>(new StandardCachingStrategy<Contact, int>());
+			repository.CachingEnabled.ShouldBeTrue();
+		}
+
+		[Test]
+		public void CachingEnabled_Should_Be_True_When_CachingStrategy_Is_Changed_From_NoCachingStrategy()
+		{
+			var repository = new InMemoryRepository<Contact, Int32>(new NoCachingStrategy<Contact, int>());
+			repository.CachingEnabled.ShouldBeFalse();
+			repository.CachingStrategy = new TimeoutCachingStrategy<Contact, int>(60);
+			repository.CachingEnabled.ShouldBeTrue();
+		}
+
+		[Test]
+		public void CachingEnabled_Should_Be_False_When_CachingStrategy_Is_Changed_To_NoCachingStrategy()
+		{
+			var repository = new InMemoryRepository<Contact, Int32>(new TimeoutCachingStrategy<Contact, int>(60));
+			repository.CachingEnabled.ShouldBeTrue();
+			repository.CachingStrategy = new NoCachingStrategy<Contact, int>();
+			repository.CachingEnabled.ShouldBeFalse();
+		}
+	}
+}


### PR DESCRIPTION
Changed the CachingStrategy setter to set CacheEnabled to false for NoCachingStrategy and true otherwise. This changes the behavior of the CacheEnabled status remaining the same as it was prior to the CachingStrategy being updated.

```
modified:   SharpRepository.Repository/RepositoryBase.cs
modified:   SharpRepository.Tests/SharpRepository.Tests.csproj
new file:   SharpRepository.Tests/Spikes/CacheEnabledSpike.cs
```
