### PR TITLE
Removed new() restriction from EfRepository<>

### DIFF
--- a/SharpRepository.EfRepository/EfCompoundKeyRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfCompoundKeyRepositoryBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data;
 using System.Data.Entity;
 using System.Linq;
 using SharpRepository.Repository;
@@ -8,7 +7,7 @@ using SharpRepository.Repository.FetchStrategies;
 
 namespace SharpRepository.EfRepository
 {
-    public class EfCompoundKeyRepositoryBase<T> : LinqCompoundKeyRepositoryBase<T> where T : class, new()
+    public class EfCompoundKeyRepositoryBase<T> : LinqCompoundKeyRepositoryBase<T> where T : class
     {
         protected IDbSet<T> DbSet { get; private set; }
         protected DbContext Context { get; private set; }
@@ -96,7 +95,7 @@ namespace SharpRepository.EfRepository
         }
     }
 
-    public class EfCompoundKeyRepositoryBase<T, TKey, TKey2> : LinqCompoundKeyRepositoryBase<T, TKey, TKey2> where T : class, new()
+    public class EfCompoundKeyRepositoryBase<T, TKey, TKey2> : LinqCompoundKeyRepositoryBase<T, TKey, TKey2> where T : class
     {
         protected IDbSet<T> DbSet { get; private set; }
         protected DbContext Context { get; private set; }
@@ -184,7 +183,7 @@ namespace SharpRepository.EfRepository
         }
     }
 
-    public class EfCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> : LinqCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> where T : class, new()
+    public class EfCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> : LinqCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> where T : class
     {
         protected IDbSet<T> DbSet { get; private set; }
         protected DbContext Context { get; private set; }

--- a/SharpRepository.EfRepository/EfRepository.cs
+++ b/SharpRepository.EfRepository/EfRepository.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Data.Entity;
+﻿using System.Data.Entity;
 using SharpRepository.Repository;
 using SharpRepository.Repository.Caching;
 
 namespace SharpRepository.EfRepository
 {
-    public class EfRepository<T, TKey, TKey2> : EfCompoundKeyRepositoryBase<T, TKey, TKey2> where T : class, new()
+    public class EfRepository<T, TKey, TKey2> : EfCompoundKeyRepositoryBase<T, TKey, TKey2> where T : class
     {
         public EfRepository(DbContext dbContext, ICompoundKeyCachingStrategy<T, TKey, TKey2> cachingStrategy = null)
             : base(dbContext, cachingStrategy)
@@ -13,7 +12,7 @@ namespace SharpRepository.EfRepository
         }
     }
 
-    public class EfCompoundKeyRepository<T> : EfCompoundKeyRepositoryBase<T> where T : class, new()
+    public class EfCompoundKeyRepository<T> : EfCompoundKeyRepositoryBase<T> where T : class
     {
         public EfCompoundKeyRepository(DbContext dbContext, ICompoundKeyCachingStrategy<T> cachingStrategy = null)
             : base(dbContext, cachingStrategy)
@@ -26,7 +25,7 @@ namespace SharpRepository.EfRepository
     /// </summary>
     /// <typeparam name="T">The Entity type</typeparam>
     /// <typeparam name="TKey">The type of the primary key.</typeparam>
-    public class EfRepository<T, TKey> : EfRepositoryBase<T, TKey> where T : class, new()
+    public class EfRepository<T, TKey> : EfRepositoryBase<T, TKey> where T : class
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EfRepository&lt;T, TKey&gt;"/> class.
@@ -42,7 +41,7 @@ namespace SharpRepository.EfRepository
     /// Entity Framework repository layer
     /// </summary>
     /// <typeparam name="T">The Entity type</typeparam>
-    public class EfRepository<T> : EfRepositoryBase<T, int>, IRepository<T> where T : class, new()
+    public class EfRepository<T> : EfRepositoryBase<T, int>, IRepository<T> where T : class
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EfRepository&lt;T&gt;"/> class.

--- a/SharpRepository.EfRepository/EfRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfRepositoryBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.Data;
 using System.Data.Entity;
 using System.Linq;
 using System.Reflection;
@@ -11,7 +10,7 @@ using SharpRepository.Repository.Helpers;
 
 namespace SharpRepository.EfRepository
 {
-    public class EfRepositoryBase<T, TKey> : LinqRepositoryBase<T, TKey> where T : class, new()
+    public class EfRepositoryBase<T, TKey> : LinqRepositoryBase<T, TKey> where T : class
     {
         protected IDbSet<T> DbSet { get; private set; }
         protected DbContext Context { get; private set; }


### PR DESCRIPTION
I added code changes for issue #124 "Remove new() restriction in EfRepository<>". I removed new() restriction only in SharpRepository.EfRepository project. Other parts of solution I didn't investigate. Unit tests ran and they passed.
