### PR TITLE
RepositoryFactory methods to get all existing compound key repository available

### DIFF
--- a/SharpRepository.CacheRepository/CacheConfigRepositoryFactory.cs
+++ b/SharpRepository.CacheRepository/CacheConfigRepositoryFactory.cs
@@ -24,5 +24,10 @@ namespace SharpRepository.CacheRepository
         {
             return new CacheRepository<T, TKey, TKey2>(RepositoryConfiguration["prefix"]);
         }
+
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            return new CacheRepository<T, TKey, TKey2, TKey3>(RepositoryConfiguration["prefix"]);
+        }
     }
 }

--- a/SharpRepository.CacheRepository/CacheConfigRepositoryFactory.cs
+++ b/SharpRepository.CacheRepository/CacheConfigRepositoryFactory.cs
@@ -29,5 +29,10 @@ namespace SharpRepository.CacheRepository
         {
             return new CacheRepository<T, TKey, TKey2, TKey3>(RepositoryConfiguration["prefix"]);
         }
+
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            return new CacheCompoundKeyRepository<T>(RepositoryConfiguration["prefix"]);
+        }
     }
 }

--- a/SharpRepository.CacheRepository/CacheRepository.cs
+++ b/SharpRepository.CacheRepository/CacheRepository.cs
@@ -44,4 +44,12 @@ namespace SharpRepository.CacheRepository
         {
         }
     }
+
+    public class CacheRepository<T, TKey, TKey2, TKey3> : CacheCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> where T : class, new()
+    {
+        public CacheRepository(string prefix, ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> cachingStrategy = null)
+            : base(prefix, cachingStrategy)
+        {
+        }
+    }
 }

--- a/SharpRepository.CouchDbRepository/SharpRepository.CouchDbRepository.csproj
+++ b/SharpRepository.CouchDbRepository/SharpRepository.CouchDbRepository.csproj
@@ -66,7 +66,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SharpRepository.CouchDbRepository/packages.config
+++ b/SharpRepository.CouchDbRepository/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
-  <package id="Remotion.Linq" version="1.13.171" targetFramework="net40" />
   <package id="Remotion.Linq" version="1.13.183.0" targetFramework="net40" />
 </packages>

--- a/SharpRepository.Db4oRepository/Db4oConfigRepositoryFactory.cs
+++ b/SharpRepository.Db4oRepository/Db4oConfigRepositoryFactory.cs
@@ -37,5 +37,10 @@ namespace SharpRepository.Db4oRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpRepository.Db4oRepository/Db4oConfigRepositoryFactory.cs
+++ b/SharpRepository.Db4oRepository/Db4oConfigRepositoryFactory.cs
@@ -32,5 +32,10 @@ namespace SharpRepository.Db4oRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpRepository.EfRepository/EfConfigRepositoryFactory.cs
+++ b/SharpRepository.EfRepository/EfConfigRepositoryFactory.cs
@@ -33,6 +33,10 @@ namespace SharpRepository.EfRepository
         {
             return new EfRepository<T, TKey, TKey2, TKey3>(GetDbContext());
         }
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            return new EfCompoundKeyRepository<T>(GetDbContext());
+        }
 
         private DbContext GetDbContext()
         {

--- a/SharpRepository.EfRepository/EfConfigRepositoryFactory.cs
+++ b/SharpRepository.EfRepository/EfConfigRepositoryFactory.cs
@@ -29,6 +29,11 @@ namespace SharpRepository.EfRepository
             return new EfRepository<T, TKey, TKey2>(GetDbContext());
         }
 
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            return new EfRepository<T, TKey, TKey2, TKey3>(GetDbContext());
+        }
+
         private DbContext GetDbContext()
         {
             var connectionString = RepositoryConfiguration["connectionString"];

--- a/SharpRepository.EfRepository/EfRepository.cs
+++ b/SharpRepository.EfRepository/EfRepository.cs
@@ -13,6 +13,14 @@ namespace SharpRepository.EfRepository
         }
     }
 
+    public class EfRepository<T, TKey, TKey2, TKey3> : EfCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> where T : class, new()
+    {
+        public EfRepository(DbContext dbContext, ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> cachingStrategy = null)
+            : base(dbContext, cachingStrategy)
+        {
+        }
+    }
+
     public class EfCompoundKeyRepository<T> : EfCompoundKeyRepositoryBase<T> where T : class, new()
     {
         public EfCompoundKeyRepository(DbContext dbContext, ICompoundKeyCachingStrategy<T> cachingStrategy = null)

--- a/SharpRepository.InMemoryRepository/InMemoryConfigRepositoryFactory.cs
+++ b/SharpRepository.InMemoryRepository/InMemoryConfigRepositoryFactory.cs
@@ -24,5 +24,10 @@ namespace SharpRepository.InMemoryRepository
         {
             return new InMemoryRepository<T, TKey, TKey2>();
         }
+
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            return new InMemoryRepository<T, TKey, TKey2, TKey3>();
+        }
     }
 }

--- a/SharpRepository.InMemoryRepository/InMemoryConfigRepositoryFactory.cs
+++ b/SharpRepository.InMemoryRepository/InMemoryConfigRepositoryFactory.cs
@@ -29,5 +29,10 @@ namespace SharpRepository.InMemoryRepository
         {
             return new InMemoryRepository<T, TKey, TKey2, TKey3>();
         }
+
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            return new InMemoryCompoundKeyRepository<T>();
+        }
     }
 }

--- a/SharpRepository.InMemoryRepository/InMemoryRepository.cs
+++ b/SharpRepository.InMemoryRepository/InMemoryRepository.cs
@@ -34,4 +34,12 @@ namespace SharpRepository.InMemoryRepository
         {
         }
     }
+
+    public class InMemoryRepository<T, TKey, TKey2, TKey3> : InMemoryCompoundKeyRepositoryBase<T, TKey, TKey2, TKey3> where T : class, new()
+    {
+        public InMemoryRepository(ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> cachingStrategy = null)
+            : base(cachingStrategy)
+        {
+        }
+    }
 }

--- a/SharpRepository.MongoDbRepository/MongoDbConfigRepositoryFactory.cs
+++ b/SharpRepository.MongoDbRepository/MongoDbConfigRepositoryFactory.cs
@@ -37,5 +37,11 @@ namespace SharpRepository.MongoDbRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            throw new NotImplementedException();
+        }
+
     }
 }

--- a/SharpRepository.MongoDbRepository/MongoDbConfigRepositoryFactory.cs
+++ b/SharpRepository.MongoDbRepository/MongoDbConfigRepositoryFactory.cs
@@ -32,5 +32,10 @@ namespace SharpRepository.MongoDbRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpRepository.RavenDbRepository/RavenDbConfigRepositoryFactory.cs
+++ b/SharpRepository.RavenDbRepository/RavenDbConfigRepositoryFactory.cs
@@ -49,5 +49,10 @@ namespace SharpRepository.RavenDbRepository
 //
 //            return new RavenDbRepository<T, TKey, TKey2>(documentStore);
         }
+
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpRepository.RavenDbRepository/RavenDbConfigRepositoryFactory.cs
+++ b/SharpRepository.RavenDbRepository/RavenDbConfigRepositoryFactory.cs
@@ -54,5 +54,10 @@ namespace SharpRepository.RavenDbRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpRepository.Repository/Caching/NoCachingConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Caching/NoCachingConfigCachingStrategyFactory.cs
@@ -18,5 +18,10 @@ namespace SharpRepository.Repository.Caching
         {
             return new NoCachingStrategy<T, TKey, TKey2>();
         }
+
+        public override ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            return new NoCachingStrategy<T, TKey, TKey2, TKey3>();
+        }
     }
 }

--- a/SharpRepository.Repository/Caching/NoCachingConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Caching/NoCachingConfigCachingStrategyFactory.cs
@@ -23,5 +23,9 @@ namespace SharpRepository.Repository.Caching
         {
             return new NoCachingStrategy<T, TKey, TKey2, TKey3>();
         }
+        public override ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>()
+        {
+            return new NoCompoundKeyCachingStrategy<T>();
+        }
     }
 }

--- a/SharpRepository.Repository/Caching/StandardCachingStrategy.cs
+++ b/SharpRepository.Repository/Caching/StandardCachingStrategy.cs
@@ -64,7 +64,35 @@ namespace SharpRepository.Repository.Caching
     public class StandardCachingStrategy<T, TKey, TKey2> : StandardCompoundKeyCachingStrategyBase<T, TKey, TKey2, int> where T : class
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="StandardCachingStrategy&lt;T, TKey&gt;"/> class.
+        /// Initializes a new instance of the <see cref="StandardCachingStrategy&lt;T, TKey, TKey2&gt;"/> class.
+        /// </summary>
+        public StandardCachingStrategy()
+            : base()
+        {
+            Partition = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardCachingStrategy&lt;T, TKey, TKey2&gt;"/> class.
+        /// </summary>
+        /// <param name="cachingProvider">The caching provider to use (e.g. <see cref="InMemoryCachingProvider"/>, <see cref="MemcachedCachingProvider"/>, etc.).  Defaults to <see cref="InMemoryCachingProvider"/>.</param>
+        public StandardCachingStrategy(ICachingProvider cachingProvider)
+            : base(null, cachingProvider)
+        {
+            Partition = null;
+        }
+    }
+
+    /// <summary>
+    /// Implements Write-Through caching for all CRUD operations (writing to the database and cache at the same time), and Generational caching for all queries (FindAll, GetAll, Find) with the option to partition the Generational Cache based on a specific entity property for better performance in certain situations.
+    /// </summary>
+    /// <typeparam name="T">Type of the entity the corresponding repository queries against.</typeparam>
+    /// <typeparam name="TKey">The first part of the compound primary key type of the entity</typeparam>
+    /// <typeparam name="TKey2">The second part of the compound primary key type of the entity</typeparam>
+    public class StandardCachingStrategy<T, TKey, TKey2, TKey3> : StandardCompoundKeyCachingStrategyBase<T, TKey, TKey2, TKey3, int> where T : class
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StandardCachingStrategy&lt;T, TKey, TKey2, TKey3&gt;"/> class.
         /// </summary>
         public StandardCachingStrategy()
             : base()
@@ -82,8 +110,6 @@ namespace SharpRepository.Repository.Caching
             Partition = null;
         }
     }
-
-
 
 
 }

--- a/SharpRepository.Repository/Caching/StandardConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Caching/StandardConfigCachingStrategyFactory.cs
@@ -51,5 +51,26 @@ namespace SharpRepository.Repository.Caching
 
             return strategy;
         }
+
+        public override ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            var strategy = new StandardCachingStrategy<T, TKey, TKey2, TKey3>()
+            {
+                MaxResults = CachingStrategyConfiguration.MaxResults
+            };
+
+            bool enabled;
+            if (Boolean.TryParse(CachingStrategyConfiguration["generational"], out enabled))
+            {
+                strategy.GenerationalCachingEnabled = enabled;
+            }
+
+            if (Boolean.TryParse(CachingStrategyConfiguration["writeThrough"], out enabled))
+            {
+                strategy.WriteThroughCachingEnabled = enabled;
+            }
+
+            return strategy;
+        }
     }
 }

--- a/SharpRepository.Repository/Caching/StandardConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Caching/StandardConfigCachingStrategyFactory.cs
@@ -72,5 +72,26 @@ namespace SharpRepository.Repository.Caching
 
             return strategy;
         }
+        
+        public override ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>()
+        {
+            var strategy = new StandardCompoundKeyCachingStrategy<T>()
+            {
+                MaxResults = CachingStrategyConfiguration.MaxResults
+            };
+
+            bool enabled;
+            if (Boolean.TryParse(CachingStrategyConfiguration["generational"], out enabled))
+            {
+                strategy.GenerationalCachingEnabled = enabled;
+            }
+
+            if (Boolean.TryParse(CachingStrategyConfiguration["writeThrough"], out enabled))
+            {
+                strategy.WriteThroughCachingEnabled = enabled;
+            }
+
+            return strategy;
+        }
     }
 }

--- a/SharpRepository.Repository/Caching/TimeoutCachingStrategy.cs
+++ b/SharpRepository.Repository/Caching/TimeoutCachingStrategy.cs
@@ -46,7 +46,28 @@
     public class TimeoutCachingStrategy<T, TKey, TKey2> : TimeoutCompoundKeyCachingStrategyBase<T, TKey, TKey2> where T : class
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TimeoutCachingStrategy&lt;T, TKey&gt;"/> class.
+        /// Initializes a new instance of the <see cref="TimeoutCachingStrategy&lt;T, TKey, TKey2&gt;"/> class.
+        /// </summary>
+        /// <param name="timeoutInSeconds">The timeout in seconds.</param>
+        /// <param name="cachingProvider">The caching provider.</param>
+        public TimeoutCachingStrategy(int timeoutInSeconds, ICachingProvider cachingProvider = null)
+            : base(timeoutInSeconds, null, cachingProvider)
+        {
+
+        }
+    }
+
+    /// <summary>
+    /// Implements a simple timeout based caching strategy where all entities and queries are cached for a certain number of seconds.  This will allow for stale data to be served up if it hasn't timed out yet so please be aware of that.
+    /// </summary>
+    /// <typeparam name="T">The entity type of the repository this is used with.</typeparam>
+    /// <typeparam name="TKey">The type of the first part of the compound primary key.</typeparam>
+    /// <typeparam name="TKey2">The type of the second part of the compound primary key.</typeparam>
+    /// <typeparam name="TKey3">The type of the third part of the compound primary key.</typeparam>
+    public class TimeoutCachingStrategy<T, TKey, TKey2, TKey3> : TimeoutCompoundKeyCachingStrategyBase<T, TKey, TKey2, TKey3> where T : class
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeoutCachingStrategy&lt;T, TKey, TKey2, TKey3&gt;"/> class.
         /// </summary>
         /// <param name="timeoutInSeconds">The timeout in seconds.</param>
         /// <param name="cachingProvider">The caching provider.</param>

--- a/SharpRepository.Repository/Caching/TimeoutConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Caching/TimeoutConfigCachingStrategyFactory.cs
@@ -55,5 +55,20 @@ namespace SharpRepository.Repository.Caching
                 MaxResults = CachingStrategyConfiguration.MaxResults
             };
         }
+
+        public override ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>()
+        {
+            int timeout;
+            if (!Int32.TryParse(CachingStrategyConfiguration["timeout"], out timeout))
+            {
+
+                throw new ConfigurationErrorsException("The timeout attribute is required in order to use the TimeoutCachingStrategy via the configuration file.");
+            }
+
+            return new TimeoutCompoundKeyCachingStrategy<T>(timeout)
+            {
+                MaxResults = CachingStrategyConfiguration.MaxResults
+            };
+        }
     }
 }

--- a/SharpRepository.Repository/Caching/TimeoutConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Caching/TimeoutConfigCachingStrategyFactory.cs
@@ -40,5 +40,20 @@ namespace SharpRepository.Repository.Caching
                            MaxResults = CachingStrategyConfiguration.MaxResults
                        };
         }
+
+        public override ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            int timeout;
+            if (!Int32.TryParse(CachingStrategyConfiguration["timeout"], out timeout))
+            {
+
+                throw new ConfigurationErrorsException("The timeout attribute is required in order to use the TimeoutCachingStrategy via the configuration file.");
+            }
+
+            return new TimeoutCachingStrategy<T, TKey, TKey2, TKey3>(timeout)
+            {
+                MaxResults = CachingStrategyConfiguration.MaxResults
+            };
+        }
     }
 }

--- a/SharpRepository.Repository/Configuration/CachingStrategyConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/CachingStrategyConfiguration.cs
@@ -45,6 +45,15 @@ namespace SharpRepository.Repository.Configuration
             return factory.GetInstance<T, TKey, TKey2>();
         }
 
+        public ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigCachingStrategyFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetInstance<T, TKey, TKey2, TKey3>();
+        }
+
+
         public string this[string key]
         {
             get { return Attributes[key]; }

--- a/SharpRepository.Repository/Configuration/CachingStrategyConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/CachingStrategyConfiguration.cs
@@ -53,6 +53,15 @@ namespace SharpRepository.Repository.Configuration
             return factory.GetInstance<T, TKey, TKey2, TKey3>();
         }
 
+        public ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigCachingStrategyFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetCompoundKeyInstance<T>();
+        }
+
+
 
         public string this[string key]
         {

--- a/SharpRepository.Repository/Configuration/CachingStrategyElement.cs
+++ b/SharpRepository.Repository/Configuration/CachingStrategyElement.cs
@@ -61,6 +61,13 @@ namespace SharpRepository.Repository.Configuration
 
             return factory.GetInstance<T, TKey, TKey2, TKey3>();
         }
+        public ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigCachingStrategyFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetCompoundKeyInstance<T>();
+        }
 
         public new string this[string key]
         {

--- a/SharpRepository.Repository/Configuration/CachingStrategyElement.cs
+++ b/SharpRepository.Repository/Configuration/CachingStrategyElement.cs
@@ -54,6 +54,13 @@ namespace SharpRepository.Repository.Configuration
 
             return factory.GetInstance<T, TKey, TKey2>();
         }
+        public ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigCachingStrategyFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetInstance<T, TKey, TKey2, TKey3>();
+        }
 
         public new string this[string key]
         {

--- a/SharpRepository.Repository/Configuration/ConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Configuration/ConfigCachingStrategyFactory.cs
@@ -7,6 +7,7 @@ namespace SharpRepository.Repository.Configuration
         ICachingStrategy<T, TKey> GetInstance<T, TKey>() where T : class;
         ICompoundKeyCachingStrategy<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class;
         ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class;
+        ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>() where T : class;
     }
 
     public abstract class ConfigCachingStrategyFactory : IConfigCachingStrategyFactory
@@ -21,5 +22,6 @@ namespace SharpRepository.Repository.Configuration
         public abstract ICachingStrategy<T, TKey> GetInstance<T, TKey>() where T : class;
         public abstract ICompoundKeyCachingStrategy<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class;
         public abstract ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class;
+        public abstract ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>() where T : class;
     }
 }

--- a/SharpRepository.Repository/Configuration/ConfigCachingStrategyFactory.cs
+++ b/SharpRepository.Repository/Configuration/ConfigCachingStrategyFactory.cs
@@ -6,6 +6,7 @@ namespace SharpRepository.Repository.Configuration
     {
         ICachingStrategy<T, TKey> GetInstance<T, TKey>() where T : class;
         ICompoundKeyCachingStrategy<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class;
+        ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class;
     }
 
     public abstract class ConfigCachingStrategyFactory : IConfigCachingStrategyFactory
@@ -19,5 +20,6 @@ namespace SharpRepository.Repository.Configuration
 
         public abstract ICachingStrategy<T, TKey> GetInstance<T, TKey>() where T : class;
         public abstract ICompoundKeyCachingStrategy<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class;
+        public abstract ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class;
     }
 }

--- a/SharpRepository.Repository/Configuration/ConfigRepositoryFactory.cs
+++ b/SharpRepository.Repository/Configuration/ConfigRepositoryFactory.cs
@@ -7,6 +7,7 @@ namespace SharpRepository.Repository.Configuration
         IRepository<T, TKey> GetInstance<T, TKey>() where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
+        ICompoundKeyRepository<T> GetCompoundKeyInstance<T>() where T : class, new();
     }
 
     public abstract class ConfigRepositoryFactory : IConfigRepositoryFactory
@@ -22,5 +23,6 @@ namespace SharpRepository.Repository.Configuration
         public abstract IRepository<T, TKey> GetInstance<T, TKey>() where T : class, new();
         public abstract ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
         public abstract ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
+        public abstract ICompoundKeyRepository<T> GetCompoundKeyInstance<T>() where T : class, new();
     }
 }

--- a/SharpRepository.Repository/Configuration/ConfigRepositoryFactory.cs
+++ b/SharpRepository.Repository/Configuration/ConfigRepositoryFactory.cs
@@ -6,6 +6,7 @@ namespace SharpRepository.Repository.Configuration
         IRepository<T> GetInstance<T>() where T : class, new();
         IRepository<T, TKey> GetInstance<T, TKey>() where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
+        ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
     }
 
     public abstract class ConfigRepositoryFactory : IConfigRepositoryFactory
@@ -20,5 +21,6 @@ namespace SharpRepository.Repository.Configuration
         public abstract IRepository<T> GetInstance<T>() where T : class, new();
         public abstract IRepository<T, TKey> GetInstance<T, TKey>() where T : class, new();
         public abstract ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
+        public abstract ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
     }
 }

--- a/SharpRepository.Repository/Configuration/ConfigurationHelper.cs
+++ b/SharpRepository.Repository/Configuration/ConfigurationHelper.cs
@@ -120,5 +120,41 @@ namespace SharpRepository.Repository.Configuration
 
             return repository;
         }
+
+        public static ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(ISharpRepositoryConfiguration configuration, string repositoryName) where T : class, new()
+        {
+            if (!configuration.HasRepository)
+            {
+                throw new Exception("There are no repositories configured");
+            }
+
+            var repositoryConfiguration = configuration.GetRepository(repositoryName);
+            var repository = repositoryConfiguration.GetInstance<T, TKey, TKey2, TKey3>();
+
+            if (repository == null)
+                return null;
+
+            var strategyConfiguration = configuration.GetCachingStrategy(repositoryConfiguration.CachingStrategy);
+            if (strategyConfiguration == null)
+            {
+                return repository;
+            }
+
+            var cachingStrategy = strategyConfiguration.GetInstance<T, TKey, TKey2, TKey3>();
+            if (cachingStrategy == null)
+            {
+                return repository;
+            }
+
+            var providerConfiguration = configuration.GetCachingProvider(repositoryConfiguration.CachingProvider);
+            if (providerConfiguration != null)
+            {
+                cachingStrategy.CachingProvider = providerConfiguration.GetInstance();
+            }
+
+            repository.CachingStrategy = cachingStrategy;
+
+            return repository;
+        }
     }
 }

--- a/SharpRepository.Repository/Configuration/ConfigurationHelper.cs
+++ b/SharpRepository.Repository/Configuration/ConfigurationHelper.cs
@@ -156,5 +156,41 @@ namespace SharpRepository.Repository.Configuration
 
             return repository;
         }
+
+        public static ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(ISharpRepositoryConfiguration configuration, string repositoryName) where T : class, new()
+        {
+            if (!configuration.HasRepository)
+            {
+                throw new Exception("There are no repositories configured");
+            }
+
+            var repositoryConfiguration = configuration.GetRepository(repositoryName);
+            var repository = repositoryConfiguration.GetCompoundKeyInstance<T>();
+
+            if (repository == null)
+                return null;
+
+            var strategyConfiguration = configuration.GetCachingStrategy(repositoryConfiguration.CachingStrategy);
+            if (strategyConfiguration == null)
+            {
+                return repository;
+            }
+
+            var cachingStrategy = strategyConfiguration.GetCompoundKeyInstance<T>();
+            if (cachingStrategy == null)
+            {
+                return repository;
+            }
+
+            var providerConfiguration = configuration.GetCachingProvider(repositoryConfiguration.CachingProvider);
+            if (providerConfiguration != null)
+            {
+                cachingStrategy.CachingProvider = providerConfiguration.GetInstance();
+            }
+
+            repository.CachingStrategy = cachingStrategy;
+
+            return repository;
+        }
     }
 }

--- a/SharpRepository.Repository/Configuration/ICachingStrategyConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/ICachingStrategyConfiguration.cs
@@ -13,6 +13,8 @@ namespace SharpRepository.Repository.Configuration
         ICachingStrategy<T, TKey> GetInstance<T, TKey>() where T : class, new();
         ICompoundKeyCachingStrategy<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
         ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
+        ICompoundKeyCachingStrategy<T> GetCompoundKeyInstance<T>() where T : class, new();
+
         string this[string key] { get; }
     }
 }

--- a/SharpRepository.Repository/Configuration/ICachingStrategyConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/ICachingStrategyConfiguration.cs
@@ -12,6 +12,7 @@ namespace SharpRepository.Repository.Configuration
         IDictionary<string, string> Attributes { get; set; }
         ICachingStrategy<T, TKey> GetInstance<T, TKey>() where T : class, new();
         ICompoundKeyCachingStrategy<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
+        ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
         string this[string key] { get; }
     }
 }

--- a/SharpRepository.Repository/Configuration/IRepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/IRepositoryConfiguration.cs
@@ -16,5 +16,6 @@ namespace SharpRepository.Repository.Configuration
         IRepository<T, TKey> GetInstance<T, TKey>() where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
+        ICompoundKeyRepository<T> GetCompoundKeyInstance<T>() where T : class, new();
     }
 }

--- a/SharpRepository.Repository/Configuration/IRepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/IRepositoryConfiguration.cs
@@ -15,5 +15,6 @@ namespace SharpRepository.Repository.Configuration
         IRepository<T> GetInstance<T>() where T : class, new();
         IRepository<T, TKey> GetInstance<T, TKey>() where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>() where T : class, new();
+        ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new();
     }
 }

--- a/SharpRepository.Repository/Configuration/ISharpRepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/ISharpRepositoryConfiguration.cs
@@ -22,5 +22,7 @@ namespace SharpRepository.Repository.Configuration
         IRepository<T> GetInstance<T>(string repositoryName = null) where T : class, new();
         IRepository<T, TKey> GetInstance<T, TKey>(string repositoryName = null) where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>(string repositoryName = null) where T : class, new();
+
+        ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string repositoryName = null) where T : class, new();
     }
 }

--- a/SharpRepository.Repository/Configuration/ISharpRepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/ISharpRepositoryConfiguration.cs
@@ -22,7 +22,7 @@ namespace SharpRepository.Repository.Configuration
         IRepository<T> GetInstance<T>(string repositoryName = null) where T : class, new();
         IRepository<T, TKey> GetInstance<T, TKey>(string repositoryName = null) where T : class, new();
         ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>(string repositoryName = null) where T : class, new();
-
         ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string repositoryName = null) where T : class, new();
+        ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(string repositoryName = null) where T : class, new();
     }
 }

--- a/SharpRepository.Repository/Configuration/RepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/RepositoryConfiguration.cs
@@ -58,6 +58,14 @@ namespace SharpRepository.Repository.Configuration
             return factory.GetInstance<T, TKey, TKey2>();
         }
 
+        public ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigRepositoryFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetInstance<T, TKey, TKey2, TKey3>();
+        }
+
         public string this[string key]
         {
             get { return Attributes.ContainsKey(key) ? Attributes[key] : null; }

--- a/SharpRepository.Repository/Configuration/RepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/RepositoryConfiguration.cs
@@ -66,6 +66,14 @@ namespace SharpRepository.Repository.Configuration
             return factory.GetInstance<T, TKey, TKey2, TKey3>();
         }
 
+        public ICompoundKeyRepository<T> GetCompoundKeyInstance<T>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigRepositoryFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetCompoundKeyInstance<T>();
+        }
+
         public string this[string key]
         {
             get { return Attributes.ContainsKey(key) ? Attributes[key] : null; }

--- a/SharpRepository.Repository/Configuration/RepositoryElement.cs
+++ b/SharpRepository.Repository/Configuration/RepositoryElement.cs
@@ -69,6 +69,14 @@ namespace SharpRepository.Repository.Configuration
             return factory.GetInstance<T, TKey, TKey2>();
         }
 
+        public ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigRepositoryFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetInstance<T, TKey, TKey2, TKey3>();
+        }
+
         public new string this[string key]
         {
             get

--- a/SharpRepository.Repository/Configuration/RepositoryElement.cs
+++ b/SharpRepository.Repository/Configuration/RepositoryElement.cs
@@ -76,6 +76,14 @@ namespace SharpRepository.Repository.Configuration
 
             return factory.GetInstance<T, TKey, TKey2, TKey3>();
         }
+        public ICompoundKeyRepository<T> GetCompoundKeyInstance<T>() where T : class, new()
+        {
+            // load up the factory if it exists and use it
+            var factory = (IConfigRepositoryFactory)Activator.CreateInstance(Factory, this);
+
+            return factory.GetCompoundKeyInstance<T>();
+        }
+
 
         public new string this[string key]
         {

--- a/SharpRepository.Repository/Configuration/SharpRepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/SharpRepositoryConfiguration.cs
@@ -152,5 +152,10 @@ namespace SharpRepository.Repository.Configuration
         {
             return ConfigurationHelper.GetInstance<T, TKey, TKey2>(this, repositoryName);
         }
+
+        public ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string repositoryName = null) where T : class, new()
+        {
+            return ConfigurationHelper.GetInstance<T, TKey, TKey2, TKey3>(this, repositoryName);
+        }
     }
 }

--- a/SharpRepository.Repository/Configuration/SharpRepositoryConfiguration.cs
+++ b/SharpRepository.Repository/Configuration/SharpRepositoryConfiguration.cs
@@ -157,5 +157,9 @@ namespace SharpRepository.Repository.Configuration
         {
             return ConfigurationHelper.GetInstance<T, TKey, TKey2, TKey3>(this, repositoryName);
         }
+        public ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(string repositoryName = null) where T : class, new()
+        {
+            return ConfigurationHelper.GetCompoundKeyInstance<T>(this, repositoryName);
+        }
     }
 }

--- a/SharpRepository.Repository/Configuration/SharpRepositorySection.cs
+++ b/SharpRepository.Repository/Configuration/SharpRepositorySection.cs
@@ -153,6 +153,11 @@ namespace SharpRepository.Repository.Configuration
             return ConfigurationHelper.GetInstance<T, TKey, TKey2>(this, repositoryName);
         }
 
+        public ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string repositoryName = null) where T : class, new()
+        {
+            return ConfigurationHelper.GetInstance<T, TKey, TKey2, TKey3>(this, repositoryName);
+        }
+
         IList<IRepositoryConfiguration> ISharpRepositoryConfiguration.Repositories
         {
             get { return Repositories.ToRepositoryConfigurationList(); }

--- a/SharpRepository.Repository/Configuration/SharpRepositorySection.cs
+++ b/SharpRepository.Repository/Configuration/SharpRepositorySection.cs
@@ -158,6 +158,11 @@ namespace SharpRepository.Repository.Configuration
             return ConfigurationHelper.GetInstance<T, TKey, TKey2, TKey3>(this, repositoryName);
         }
 
+        public ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(string repositoryName = null) where T : class, new()
+        {
+            return ConfigurationHelper.GetCompoundKeyInstance<T>(this, repositoryName);
+        }
+
         IList<IRepositoryConfiguration> ISharpRepositoryConfiguration.Repositories
         {
             get { return Repositories.ToRepositoryConfigurationList(); }

--- a/SharpRepository.Repository/RepositoryFactory.cs
+++ b/SharpRepository.Repository/RepositoryFactory.cs
@@ -138,7 +138,7 @@ namespace SharpRepository.Repository
             return genericMethod.Invoke(configuration, new object[] { repositoryName });
         }
 
-        // compound key triple key methods
+        // triple compound key methods
 
         public static ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string repositoryName = null) where T : class, new()
         {
@@ -149,8 +149,7 @@ namespace SharpRepository.Repository
         {
             return GetInstance(entityType, keyType, key2Type, key3Type, DefaultConfigSection, repositoryName);
         }
-
-
+        
         public static ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string configSection, string repositoryName) where T : class, new()
         {
             return GetInstance<T, TKey, TKey2, TKey3>(GetConfiguration(configSection), repositoryName);
@@ -184,6 +183,55 @@ namespace SharpRepository.Repository
             var genericMethod = method.MakeGenericMethod(entityType, keyType, key2Type, key3Type);
             return genericMethod.Invoke(configuration, new object[] { repositoryName });
         }
+
+        /// compound key no generics methods
+
+        public static ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(string repositoryName = null) where T : class, new()
+        {
+            return GetCompoundKeyInstance<T>(DefaultConfigSection, repositoryName);
+        }
+
+        public static object GetCompoundKeyInstance(Type entityType, string repositoryName = null)
+        {
+            return GetCompoundKeyInstance(entityType, DefaultConfigSection, repositoryName);
+        }
+
+
+        public static ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(string configSection, string repositoryName) where T : class, new()
+        {
+            return GetCompoundKeyInstance<T>(GetConfiguration(configSection), repositoryName);
+        }
+
+        public static object GetCompoundKeyInstance(Type entityType, string configSection, string repositoryName)
+        {
+            return GetCompoundKeyInstance(entityType, GetConfiguration(configSection), repositoryName);
+        }
+
+        public static ICompoundKeyRepository<T> GetCompoundKeyInstance<T>(ISharpRepositoryConfiguration configuration, string repositoryName = null) where T : class, new()
+        {
+            if (String.IsNullOrEmpty(repositoryName))
+            {
+                // if no specific repository is provided then check to see if the SharpRepositoryConfigurationAttribute is used
+                repositoryName = GetAttributeRepositoryName(typeof(T));
+            }
+
+            return configuration.GetCompoundKeyInstance<T>(repositoryName);
+        }
+
+        public static object GetCompoundKeyInstance(Type entityType, ISharpRepositoryConfiguration configuration, string repositoryName = null)
+        {
+            if (String.IsNullOrEmpty(repositoryName))
+            {
+                // if no specific repository is provided then check to see if the SharpRepositoryConfigurationAttribute is used
+                repositoryName = GetAttributeRepositoryName(entityType);
+            }
+
+            var method = typeof(ISharpRepositoryConfiguration).GetMethods().First(m => m.Name == "GetCompoundKeyInstance");
+            var genericMethod = method.MakeGenericMethod(entityType);
+            return genericMethod.Invoke(configuration, new object[] { repositoryName });
+        }
+
+        //helper methods for configuration
 
         private static SharpRepositorySection GetConfiguration(string sectionName)
         {

--- a/SharpRepository.Repository/RepositoryFactory.cs
+++ b/SharpRepository.Repository/RepositoryFactory.cs
@@ -103,7 +103,7 @@ namespace SharpRepository.Repository
         {
             return GetInstance(entityType, keyType, key2Type, DefaultConfigSection, repositoryName);
         }
-
+       
         public static ICompoundKeyRepository<T, TKey, TKey2> GetInstance<T, TKey, TKey2>(string configSection, string repositoryName) where T : class, new()
         {
             return GetInstance<T, TKey, TKey2>(GetConfiguration(configSection), repositoryName);
@@ -135,6 +135,53 @@ namespace SharpRepository.Repository
 
             var method = typeof(ISharpRepositoryConfiguration).GetMethods().First(m => m.Name == "GetInstance" && m.ReturnType.Name == "ICompoundKeyRepository`3");
             var genericMethod = method.MakeGenericMethod(entityType, keyType, key2Type);
+            return genericMethod.Invoke(configuration, new object[] { repositoryName });
+        }
+
+        // compound key triple key methods
+
+        public static ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string repositoryName = null) where T : class, new()
+        {
+            return GetInstance<T, TKey, TKey2, TKey3>(DefaultConfigSection, repositoryName);
+        }
+
+        public static object GetInstance(Type entityType, Type keyType, Type key2Type, Type key3Type, string repositoryName = null)
+        {
+            return GetInstance(entityType, keyType, key2Type, key3Type, DefaultConfigSection, repositoryName);
+        }
+
+
+        public static ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(string configSection, string repositoryName) where T : class, new()
+        {
+            return GetInstance<T, TKey, TKey2, TKey3>(GetConfiguration(configSection), repositoryName);
+        }
+
+        public static object GetInstance(Type entityType, Type keyType, Type key2Type, Type key3Type, string configSection, string repositoryName)
+        {
+            return GetInstance(entityType, keyType, key2Type, key3Type, GetConfiguration(configSection), repositoryName);
+        }
+
+        public static ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>(ISharpRepositoryConfiguration configuration, string repositoryName = null) where T : class, new()
+        {
+            if (String.IsNullOrEmpty(repositoryName))
+            {
+                // if no specific repository is provided then check to see if the SharpRepositoryConfigurationAttribute is used
+                repositoryName = GetAttributeRepositoryName(typeof(T));
+            }
+
+            return configuration.GetInstance<T, TKey, TKey2, TKey3>(repositoryName);
+        }
+
+        public static object GetInstance(Type entityType, Type keyType, Type key2Type, Type key3Type, ISharpRepositoryConfiguration configuration, string repositoryName = null)
+        {
+            if (String.IsNullOrEmpty(repositoryName))
+            {
+                // if no specific repository is provided then check to see if the SharpRepositoryConfigurationAttribute is used
+                repositoryName = GetAttributeRepositoryName(entityType);
+            }
+
+            var method = typeof(ISharpRepositoryConfiguration).GetMethods().First(m => m.Name == "GetInstance" && m.ReturnType.Name == "ICompoundKeyRepository`4");
+            var genericMethod = method.MakeGenericMethod(entityType, keyType, key2Type, key3Type);
             return genericMethod.Invoke(configuration, new object[] { repositoryName });
         }
 

--- a/SharpRepository.Samples/SharpRepository.Samples.csproj
+++ b/SharpRepository.Samples/SharpRepository.Samples.csproj
@@ -73,6 +73,9 @@
       <Name>SharpRepository.Repository</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SharpRepository.Tests.Integration/SharpRepository.Tests.Integration.csproj
+++ b/SharpRepository.Tests.Integration/SharpRepository.Tests.Integration.csproj
@@ -226,7 +226,9 @@
       <Name>SharpRepository.XmlRepository</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <Content Include="Data\Db4o\README.txt" />
     <Content Include="Data\Ef\README.txt" />

--- a/SharpRepository.Tests/Configuration/ConfigurationTests.cs
+++ b/SharpRepository.Tests/Configuration/ConfigurationTests.cs
@@ -173,5 +173,16 @@ namespace SharpRepository.Tests.Configuration
                 throw new Exception("Not InMemoryRepository");
             }
         }
+
+        [Test]
+        public void TestFactoryOverloadMethodForTripleCompoundKey()
+        {
+            var repos = RepositoryFactory.GetInstance(typeof(Contact), typeof(string), typeof(string), typeof(string));
+
+            if (!(repos is InMemoryRepository<Contact, string, string, string>))
+            {
+                throw new Exception("Not InMemoryRepository");
+            }
+        }
     }
 }

--- a/SharpRepository.Tests/Configuration/ConfigurationTests.cs
+++ b/SharpRepository.Tests/Configuration/ConfigurationTests.cs
@@ -184,5 +184,16 @@ namespace SharpRepository.Tests.Configuration
                 throw new Exception("Not InMemoryRepository");
             }
         }
+
+        [Test]
+        public void TestFactoryOverloadMethodForNoGenericsCompoundKey()
+        {
+            var repos = RepositoryFactory.GetCompoundKeyInstance(typeof(Contact));
+
+            if (!(repos is InMemoryCompoundKeyRepository<Contact>))
+            {
+                throw new Exception("Not InMemoryRepository");
+            }
+        }
     }
 }

--- a/SharpRepository.Tests/PrimaryKey/Ef5PrimaryKeyTests.cs
+++ b/SharpRepository.Tests/PrimaryKey/Ef5PrimaryKeyTests.cs
@@ -19,6 +19,20 @@ namespace SharpRepository.Tests.PrimaryKey
             propInfo.PropertyType.ShouldEqual(typeof(int));
             propInfo.Name.ShouldEqual("KeyInt2");
         }
+
+        [Test]
+        public void Should_Return_KeyInt1_2_3_Property()
+        {
+            var repos = new TestTripleKeyEfRepository<TripleObjectKeys, int, int, int>(new DbContext("test"));
+            var propInfo = repos.TestGetPrimaryKeyPropertyInfo();
+
+            propInfo[0].PropertyType.ShouldEqual(typeof(int));
+            propInfo[0].Name.ShouldEqual("KeyInt1");
+            propInfo[1].PropertyType.ShouldEqual(typeof(int));
+            propInfo[1].Name.ShouldEqual("KeyInt2");
+            propInfo[2].PropertyType.ShouldEqual(typeof(int));
+            propInfo[2].Name.ShouldEqual("KeyInt3");
+        }
     }
 
     internal class TestEfRepository<T, TKey> : EfRepository.EfRepository<T, TKey> where T : class, new()
@@ -28,6 +42,18 @@ namespace SharpRepository.Tests.PrimaryKey
         }
 
         public PropertyInfo TestGetPrimaryKeyPropertyInfo()
+        {
+            return GetPrimaryKeyPropertyInfo();
+        }
+    }
+
+    internal class TestTripleKeyEfRepository<T, TKey, TKey2, TKey3> : EfRepository.EfRepository<T, TKey, TKey2, TKey3> where T : class, new()
+    {
+        public TestTripleKeyEfRepository(DbContext dbContext, ICompoundKeyCachingStrategy<T, TKey, TKey2, TKey3> cachingStrategy = null) : base(dbContext, cachingStrategy)
+        {
+        }
+
+        public PropertyInfo[] TestGetPrimaryKeyPropertyInfo()
         {
             return GetPrimaryKeyPropertyInfo();
         }

--- a/SharpRepository.Tests/SharpRepository.Tests.csproj
+++ b/SharpRepository.Tests/SharpRepository.Tests.csproj
@@ -117,6 +117,8 @@
     <Compile Include="Spikes\GenericClassInheritanceSpikes.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestObjects\PrimaryKeys\TripleObjectKeys.cs" />
+    <Compile Include="TestObjects\TripleCompoundKeyItem.cs" />
     <Compile Include="TestObjects\CompoundKeyItem.cs" />
     <Compile Include="TestObjects\Contact.cs" />
     <Compile Include="TestObjects\ContactType.cs" />
@@ -166,7 +168,9 @@
       <Name>SharpRepository.XmlRepository</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SharpRepository.Tests/Spikes/CompoundKeySpikes.cs
+++ b/SharpRepository.Tests/Spikes/CompoundKeySpikes.cs
@@ -46,8 +46,7 @@ namespace SharpRepository.Tests.Spikes
 
             repository.FindAll(x => x.SomeId == 1).Count().ShouldEqual(3);
         }
-
-
+        
         [Test]
         public void TripleCompoundKeyRepository_Should_Work()
         {
@@ -85,7 +84,5 @@ namespace SharpRepository.Tests.Spikes
 
             repository.FindAll(x => x.LastId == 11).Count().ShouldEqual(3);
         }
-
-
     }
 }

--- a/SharpRepository.Tests/Spikes/CompoundKeySpikes.cs
+++ b/SharpRepository.Tests/Spikes/CompoundKeySpikes.cs
@@ -46,5 +46,46 @@ namespace SharpRepository.Tests.Spikes
 
             repository.FindAll(x => x.SomeId == 1).Count().ShouldEqual(3);
         }
+
+
+        [Test]
+        public void TripleCompoundKeyRepository_Should_Work()
+        {
+            var repository = new InMemoryRepository<TripleCompoundKeyItemInts, int, int, int>();
+
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 1, AnotherId = 1, LastId = 10, Title = "1-1-10" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 1, AnotherId = 2, LastId = 11, Title = "1-2-11" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 1, AnotherId = 3, LastId = 10, Title = "1-3-10" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 2, AnotherId = 1, LastId = 11, Title = "2-1-11" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 2, AnotherId = 2, LastId = 10, Title = "2-2-10" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 2, AnotherId = 3, LastId = 11, Title = "2-3-11" });
+
+            repository.Get(1, 1, 10).Title.ShouldEqual("1-1-10");
+            repository.Get(2, 1, 11).Title.ShouldEqual("2-1-11");
+            repository.Get(1, 2, 11).Title.ShouldEqual("1-2-11");
+
+            repository.FindAll(x => x.LastId == 11).Count().ShouldEqual(3);
+        }
+
+        [Test]
+        public void TripleCompoundKeyRepositoryNoGenerics_Should_Work()
+        {
+            var repository = new InMemoryCompoundKeyRepository<TripleCompoundKeyItemInts>();
+
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 1, AnotherId = 1, LastId = 10, Title = "1-1-10" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 1, AnotherId = 2, LastId = 11, Title = "1-2-11" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 1, AnotherId = 3, LastId = 10, Title = "1-3-10" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 2, AnotherId = 1, LastId = 11, Title = "2-1-11" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 2, AnotherId = 2, LastId = 10, Title = "2-2-10" });
+            repository.Add(new TripleCompoundKeyItemInts { SomeId = 2, AnotherId = 3, LastId = 11, Title = "2-3-11" });
+
+            repository.Get(1, 1, 10).Title.ShouldEqual("1-1-10");
+            repository.Get(2, 1, 11).Title.ShouldEqual("2-1-11");
+            repository.Get(1, 2, 11).Title.ShouldEqual("1-2-11");
+
+            repository.FindAll(x => x.LastId == 11).Count().ShouldEqual(3);
+        }
+
+
     }
 }

--- a/SharpRepository.Tests/TestObjects/PrimaryKeys/TripleObjectKeys.cs
+++ b/SharpRepository.Tests/TestObjects/PrimaryKeys/TripleObjectKeys.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+using System.ComponentModel.DataAnnotations.Schema;
+using SharpRepository.Repository;
+
+namespace SharpRepository.Tests.TestObjects.PrimaryKeys
+{
+    public class TripleObjectKeys
+    {
+        public int Id { get; set; }
+        
+        [Key, Column(Order = 0)]
+        [RepositoryPrimaryKey(Order = 0)]
+        public int KeyInt1 { get; set; }
+
+        [Key, Column(Order = 1)]
+        [RepositoryPrimaryKey(Order = 1)]
+        public int KeyInt2 { get; set; }
+
+        [Key, Column(Order = 2)]
+        [RepositoryPrimaryKey(Order = 2)]
+        public int KeyInt3 { get; set; }
+    }
+}

--- a/SharpRepository.Tests/TestObjects/TestObjectEntities.cs
+++ b/SharpRepository.Tests/TestObjects/TestObjectEntities.cs
@@ -12,5 +12,6 @@ namespace SharpRepository.Tests.TestObjects
         public DbSet<Contact> Contacts { get; set; }
         public DbSet<PhoneNumber> PhoneNumbers { get; set; }
         public DbSet<EmailAddress> EmailAddresses { get; set; }
+        public DbSet<TripleCompoundKeyItemInts> TripleCompoundKeyItems { get; set; }
     }
 }

--- a/SharpRepository.Tests/TestObjects/TripleCompoundKeyItem.cs
+++ b/SharpRepository.Tests/TestObjects/TripleCompoundKeyItem.cs
@@ -1,0 +1,18 @@
+﻿using SharpRepository.Repository;
+
+namespace SharpRepository.Tests.TestObjects
+{
+    public class TripleCompoundKeyItemInts
+    {
+        [RepositoryPrimaryKey(Order = 1)]
+        public int SomeId { get; set; }
+
+        [RepositoryPrimaryKey(Order = 2)]
+        public int AnotherId { get; set; }
+
+        [RepositoryPrimaryKey(Order = 3)]
+        public int LastId { get; set; }
+
+        public string Title { get; set; }
+    }
+}

--- a/SharpRepository.XmlRepository/XmlConfigRepositoryFactory.cs
+++ b/SharpRepository.XmlRepository/XmlConfigRepositoryFactory.cs
@@ -38,5 +38,10 @@ namespace SharpRepository.XmlRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T, TKey, TKey2, TKey3> GetInstance<T, TKey, TKey2, TKey3>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpRepository.XmlRepository/XmlConfigRepositoryFactory.cs
+++ b/SharpRepository.XmlRepository/XmlConfigRepositoryFactory.cs
@@ -43,5 +43,10 @@ namespace SharpRepository.XmlRepository
         {
             throw new NotImplementedException();
         }
+
+        public override ICompoundKeyRepository<T> GetCompoundKeyInstance<T>()
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
As requested in https://github.com/SharpRepository/SharpRepository/issues/139 I did the pull request in order to fill the lack of RepositoryFactory methods to get all existing compound key repository available.

It's my first time, I hope there are no problems.

I created the overload Methods
```
RepositoryFactory.GetInstace<T, TKey, TKey2, TKey3>()
```
for triple key.

For the `ICompoundKeyRepository<T>` `GetInstance<T>` is already implemented, so I created
```
RepositoryFactory.GetCompoundKeyInstance<T>()
```