### PR TITLE
Removed duplicate entires for two NuGet packages.

### DIFF
--- a/SharpRepository.CouchDbRepository/packages.config
+++ b/SharpRepository.CouchDbRepository/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
-  <package id="Remotion.Linq" version="1.13.171" targetFramework="net40" />
   <package id="Remotion.Linq" version="1.13.183.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
NuGet restore won't work when there are duplicate entries for the same package IDs.