### PR TITLE
Opt out of GeneratePrimaryKey

### DIFF
--- a/.nuget/NUnit.ConsoleRunner.3.7.0/CHANGES.txt
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/CHANGES.txt
@@ -1,0 +1,1289 @@
+﻿NUnit 3.7 - July 13, 2017
+
+Engine
+
+ * Creates a .NET Standard version of the engine for use in the Visual Studio Adapter
+ * Fixes several issues that caused the runner to exit with a SocketException
+
+Console
+
+ * Created Chocolatey packages for the console runner
+
+Issues Resolved
+
+ * 10 Create a .NET Standard version of the Engine
+ * 11 insufficient info on driver reflection exception
+ * 12 Upgrade Cake build to latest version
+ * 24 Update --labels switch with option to show real-time pass/fail results in console runner
+ * 31 Nunit 3.4.1 NUnit.Engine.Runners
+ * 72 TestContext.Progress.Write writes new line
+ * 82 Remove unused repository paths from repositories.config
+ * 99 Remove unused --verbose and --full command line options
+ * 126 Resolve differences between NUnit Console and NUnitLite implementations of @filename
+ * 162 Add namespace keyword to Test Selection Language
+ * 171 Socket Exception when stopping Remote Agent
+ * 172 Limit Language level to C#6
+ * 193 Settings are stored with invariant culture but retrieved with CurrentCulture
+ * 194 Better logging or error handling in SettingsStore.SaveSettings
+ * 196 Allow comments in @FILE files
+ * 200 Remove obsolete warnings from build script
+ * 206 Remove reference to removed noxml option
+ * 207 Create Chocolatey package(s) for the console
+ * 208 Explore flags test update
+ * 213 Master build failing after merging .NET Standard Engine
+ * 216 Compiling mock-assembly in Visual Studio 2017 fails
+ * 217 NUnit .NET Standard NuGet package missing some values
+ * 219 Runtime.Remoting.RemotingException in NUnit.Engine.Runners.ProcessRunner.Dispose
+ * 221 Added missing nuget package info
+ * 222 Improve missing agent error message
+ * 225 SocketException thrown by nunit3-console.exe --explore option
+ * 248 Agent TestEngine contains duplicate services
+ * 254 Correct misprint ".con" -> ".com"
+ * 252 Console crashes when specifying both format and transform for result
+
+NUnit 3.6.1 - March 6, 2017
+
+Engine
+
+ * This hotfix release addresses a race condition in the Engine that caused
+   tests to intermittently fail.
+
+Issues Resolved
+
+ * 168 Intermittent errors while running tests after updating to 3.6
+
+NUnit 3.6 - January 14, 2017
+
+Console Runner
+
+ * Added command line option --skipnontestassemblies to skip assemblies that do
+   not contain tests without raising an error and to skip assemblies that contain
+   the NUnit.Framework.NonTestAssemblyAttribute.
+ * Messages from the new Multiple Assert blocks will be displayed individually
+ * Warnings from the new Warn.If, Warn.Unless and Assert.Warn are now displayed
+
+Engine
+
+ * NUnit agents now monitor the running engine process and will terminate themselves
+   if the parent runner process is killed or dies
+
+Issues Resolved
+
+ * 16 NUnit Engine Tests fail if not run from test directory
+ * 18 Invalid file type is shown in XML as type="Assembly"
+ * 23 In nunit3-console you cannot pass parameters containing ';' because they always get split
+ * 37 NUnit 3 console should produce xml events for ITestEventListener which contain
+      unique id in the scope of all test agents for NUnit 2 tests
+ * 58 System.Configuration.ConfigurationErrorsException thrown in multiple domain mode.
+ * 62 NUnit3 Fails on DLL with no Tests, Unlike NUnit2
+ * 100 Class NUnit.Engine.Services.ResultWriters.Tests.SchemaValidator is never used
+ * 101 Method NUnit.Options.OptionSet.Unprocessed always returns "false"
+ * 104 Type of variable enumerated in 'foreach' is not guaranteed to be castable
+ * 110 Writability check could give a friendlier message.
+ * 113 Add task descriptions to Build.cake
+ * 127 Modify console runner to display multiple assert information
+ * 128 Terminate agent if main process has terminated
+ * 133 NUnit downloadable packages zip file naming is confusing and non-intuitive
+ * 136 Handle early termination of multiple assert block
+ * 138 Report Warnings in console runner
+ * 145 MasterTestRunner.RunAsync no longer provides start-run and test-run events
+ * 151 Unexpected behaviour from --framework flag
+ * 153 Remove some settings used by the engine
+ * 156 Use high-quality icon for nuspecs
+ * 157 Fix Detection of invalid framework when --inprocess
+ * 159 Update extension versions in the NuSpec Files
+
+NUnit 3.5 - October 11, 2016
+
+This is the first version of NUnit where the framework will be released separately from the
+console runner, engine and other extensions. From this point forward, the NUnit console and engine will be
+released on its own schedule that is not bound to that of any other NUnit project and version numbers
+may diverge over time.
+
+This is also the first release where the NUnit Framework will not be included in the installer. Only
+the console runner, engine and extensions will be available as an MSI installer.
+
+Console Runner
+
+ * When running multiple assemblies in their own projects with `--agents` set to a number that is
+   lower than the number of assemblies, the number of concurrent processes is limited to that number.
+   Previously, all processes were created at the start of the run.
+
+Engine
+
+ * All of our extensions have been moved to separate repositories and are now built and
+   distributed separately. This includes the NUnit V2 Driver, NUnit V2 Result Writer,
+   NUnit Project Loader and VS Project Loader. The Teamcity extension was moved to its
+   own repository previously.
+
+* Newer versions of Mono are now detected and used under Windows when requested.
+
+* It is now possible to write a custom framework driver extension for NUnit 3, which will
+  be used instead of the built-in driver.
+
+Issues Resolved Prior to Split (These are in the nunit repository)
+
+ * 1389 specifying solution and --agents is not working with nunit3-console
+ * 1595	Separate installer project
+ * 1596 Eliminate code sharing across projects to be split
+ * 1598 Split framework and console/engine into separate projects
+ * 1600 Split Engine Extensions into separarate projects
+ * 1610 Refactor dependencies in build.cake
+ * 1621 Remove console and command-line option files from common
+ * 1641 Create OSX CI Build on Travis
+ * 1677 Console help should indicate extension needed to use --teamcity
+ * 1687 Create nunit.engine.api NuGet package
+ * 1702 Create separate repo for teamcity event listener extension
+ * 1716 Move installer to new repository
+ * 1717 Change suffix for master builds
+ * 1719 Restore teamcity extension to NUnit.Console and NUnit.Runners packages
+ * 1723 Remove Cake target TestAll
+ * 1727 V2 Framework Driver does not include class or method name in XML
+ * 1732 NullReferenceException when using either --inprocess or --domain=Multiple options
+ * 1739 Create separate copies of MockAssembly for framework, engine and extensions
+ * 1741 --domain=None does not work
+ * 1776 Logger in DefaultTestAssemblyBuilder is retrieved before InternalTrace is initialized
+ * 1800 Remove Console/Engine projects from nunit.linux.sln
+
+Issues Resolved After Split (These are in the nunit-console repository)
+
+ * 2	Split Engine Extensions into separate projects
+ * 30	Error message "File type is not supported" when uses .nunit configuration file
+ * 34	Mono detection on Windows broken
+ * 36	Console runner spawns too many agents
+ * 43	Agent's process stays in memory when it was failed to unload appdomain
+ * 47	Move V2 framework driver extension to its own repo
+ * 48	Move V2 XML result writer to its own repo
+ * 49	Move NUnit project loader to its own repo
+ * 50	Move VS project loader to its own repo
+ * 63	--encoding option for Console stdout
+ * 67	Update text of NUnit.ConsoleRunner NuGet package
+ * 70	Allow custom framework drivers to run before NUnit3DriverFactory
+ * 88	The --labels:All option displays at the wrong time
+
+NUnit 3.4.1 - June 30, 2016
+
+Console Runner
+
+ * A new option, --list-extensions, will display all the engine extensions that
+   have been installed by the engine.
+
+Issues Resolved
+
+ * 1623 NUnit 3.4 is not integrated with TeamCity
+ * 1626 NUnit.ConsoleRunner is not picking up NUnit.Extension.NUnitV2ResultWriter
+ * 1628 Agent's process stays in memory when it was failed to unload AppDomain
+ * 1635 Console option to list loaded extensions
+
+NUnit 3.4 - June 25, 2016
+
+Framework
+
+ * Improvements in comparing equality using IEquatable<T>
+ * Test case names will only be truncated if the runner requests it or it is overridden on the command line
+   with the --test-name-format option
+ * The .NET 2.0 version of the framework now includes LINQ. If your tests target .NET 2.0, you can now use
+   LINQ queries in your tests
+
+Engine
+
+ * The TeamCity event listener has been separated out into an engine extension
+ * Fixed numerous issues around thread safety of parallel test runs
+ * Additional fixes to reduce memory usage
+ * Fixes for Mono 4.4
+
+Console Runner
+
+ * There is a new --params command line option that allows you to pass parameters to your tests
+   which can be retrieved using TestContext.Parameters
+ * Another new command line option --loaduserprofile causes the User Profile to be loaded into the
+   NUnit Agent process.
+
+Issues Resolved
+
+ * 329 (CLI) Runner does not report AppDomain unloading timeout
+ * 720 Need a way to get test-specific command-line arguments at runtime
+ * 1010 Need to control engine use of extensions
+ * 1139 Nunit3 console doesn't show test output continously
+ * 1225 The --teamcity option should really be an extension
+ * 1241 Make TestDirectory accessible when TestCaseSource attributes are evaluated
+ * 1366 Classname for inherited test is not correct
+ * 1371 Support `dotnet test` in .NET CLI and .NET Core
+ * 1379 Console returns 0 for invalid fixtures
+ * 1422 Include TestListWithEmptyLine.tst in ZIP Package
+ * 1423 SingleThreaded attribute should raise an error if a thread is required
+ * 1425 Lazy initialization of OutWriter in TestResult is not thread safe
+ * 1427 Engine extensions load old packages
+ * 1430 TestObjects are retained for lifetime of test run, causing high memory usage
+ * 1432 NUnit hangs when reporting to TeamCity
+ * 1434 TestResult class needs to be thread-safe
+ * 1435 Parallel queue creation needs to be thread-safe
+ * 1436 CurrentFramework and Current Platform need to be more thread-safe
+ * 1439 EqualConstraint does Not use Equals Override on the Expected Object
+ * 1441 Add Linq for use internally in .NET 2.0 code
+ * 1446 TestOrderAttributeTests is not public
+ * 1450 Silverlight detection doesn't work when building on 32-bit OS
+ * 1457 Set the 2.0 build to ignore missing xml dcoumentation
+ * 1463 Should TestResult.AssertCount have a public setter?
+ * 1464 TNode.EscapeInvalidXmlCharacters recreates Regex continually
+ * 1470 Make EventQueue and associated classes lock-less and thread safe
+ * 1476 Examine need for "synchronous" events in event queue
+ * 1481 TestCase with generic return type causes NullReferenceException
+ * 1483 Remoting exceptions during test execution
+ * 1484 Comparing Equality using IEquatable<T> Should Use Most Specific Method
+ * 1493 NUnit 2 test results report ParameterizedMethod but should be ParameterizedTest
+ * 1507 NullReferenceException when null arguments are used in TestFixtureAttribute
+ * 1513 Add new teamcity extension to packages
+ * 1518 NUnit does not send the "testStarted" TeamCity service message when exception was thrown from SetUp/OneTimeSetUp
+ * 1520 Detect Portable, Silverlight and Compact and give error message
+ * 1528 Use of Sleep(0) in NUnit
+ * 1543 Blank name attribute in nunit2-formatted XML result file test-run element
+ * 1547 Create separate assembly for System.Linq compatibility classes
+ * 1548 Invalid Exception when engine is in a 32-bit process
+ * 1549 Changing default behavior for generating test case names
+ * 1551 Path in default .addins file for ConsoleRunner package may not exist
+ * 1555 EndsWith calls in Constraint constructor can cause major perf issues
+ * 1560 Engine writes setting file unnecessarily
+ * 1573 Move Nunit.Portable.Agent to new Repo
+ * 1579 NUnit v3 dangerously overrides COMPLUS_Version environment variable
+ * 1582 Mono 4.4.0 Causes Test Failures
+ * 1593 Nunit Console Runner 3.2.1 and Mono 4.4 throws RemotingException
+ * 1597 Move Portable agent to its own repository
+ * 1605 TeamCity package has no pre-release suffix
+ * 1607 nunit.nuget.addins discovery pattern is wrong then restored through project.json
+ * 1617 Load user profile on test runners
+
+NUnit 3.2.1 - April 19, 2016
+
+Framework
+
+ * The output and error files are now thread safe when running tests in parallel
+ * Added a .NET 3.5 build of the framework preventing conflicts with the compatiblity classes in the 2.0 framework
+ * Added a SingleThreadedAttribute to be added to a TestFixture to indicate all child tests should run on the same thread
+
+Engine
+
+ * Unless required, run all tests within a fixture on the same thread
+ * Added an EventListener extension point
+ * Reduced memory usage
+
+Console Runner
+
+ * No longer probes for newer versions of the engine, instead uses the engine that is included with the console
+
+Issues Resolved
+
+ *  332 Add CF to the Appveyor CI build
+ *  640 Keep CF Build (and other future builds) in Sync
+ *  773 Upgrade Travis CI from Legacy Infrastructure
+ * 1141 Explicit Tests get run when using --where with some filters
+ * 1161 NUnit3-Console should disallow the combination of --inprocess and --x86, giving an error message
+ * 1208 Apartment on assembly level broken
+ * 1231 Build may silently fail some tests
+ * 1247 Potential memory issue
+ * 1266 SetCultureAttribute does not work if set on assembly level
+ * 1302 Create EventListener ExtensionPoint for the Engine
+ * 1317 Getting CF framework unit tests running on CI build
+ * 1318 NUnit console runner fails with error code -100
+ * 1327 TestCaseSource in NUnit 3 converts an argument declared as String[] to String
+ * 1329 Unable to build without Compact Framework
+ * 1333 Single Thread per Worker
+ * 1338 BUILDING.txt is outdated
+ * 1349 Collision on System.Func from nunit.framework with System.Core in .Net 3.5 (CS0433)
+ * 1352 Tests losing data setup on thread
+ * 1359 Compilation error in NUnitPortableDriverTests.cs
+ * 1383 Skip Silverlight build if SDK not installed
+ * 1386 Bug when using Assert.Equals() with types that explicitly implement IEquatable<T>
+ * 1390 --testlist with file with blank first line causes IndexOutOfRangeException
+ * 1399 Fixed NullReference issue introduced by the fix for #681
+ * 1405 ITestRunner.StopRun throws exception of type 'System.MissingMethodException'
+ * 1406 TextCapture is not threadsafe but is used to intercept calls that are expected to be threadsafe
+ * 1410 Make OutFile and ErrFile streamwriters synchronized
+ * 1413 Switch console to use a local engine
+
+NUnit 3.2 - March 5, 2016
+
+Framework
+
+ * Added an Order attribute that defines the order in which tests are run
+ * Added Assert.ThrowsAsync for testing if async methods throw an exception
+ * You can now compare unlike collections using Is.EquivalentTo().Using(...)
+ * Added the ability to add custom message formatters to MsgUtils
+ * TestCaseSourceAttribute now optionally takes an array of parameters that can be passed to the source method
+ * Added Is.Zero and Is.Not.Zero to the fluent syntax as a shorter option for Is.EqualTo(0) and Is.Not.EqualTo(0)
+
+Engine
+
+ * Engine extensions can be installed via NuGet packages
+
+Issues Resolved
+
+ * 170 Test Order Attribute
+ * 300 Create an NUnit Visual Studio Template
+ * 464 Async delegate assertions
+ * 532 Batch runner for Silverlight tests
+ * 533 Separate NUnitLite runner and autorunner
+ * 681 NUnit agent cannot resolve test dependency assemblies when mixed mode initialization runs in the default AppDomain
+ * 793 Replace CoreEngine by use of Extensions
+ * 907 Console report tests are too fragile
+ * 922 Wrap Console in NUnitLite
+ * 930 Switch from MSBuild based build system to Cake
+ * 981 Define NUnit Versioning for post-3.0 Development
+ * 1004 Poor formatting of results for Assert.AreEqual(DateTimeOffset, DateTimeOffset)
+ * 1018 ArgumentException when 2.x version of NUnit Framework is in the bin directory
+ * 1022 Support Comparing Unlike Collections using Is.EquivalentTo().Using(...)
+ * 1044 Re-order Test Summary Errors/Failures
+ * 1066 ApartmentAttribute and TestCaseAttribute(s) do not work together
+ * 1103 Can't use TestCaseData from base class
+ * 1109 NullReferenceException when using inherited property for ValueSource
+ * 1113 Console runner and xml output consistency
+ * 1117 Fix misbehaviour of Throws.Exception with non-void returning functions
+ * 1120 NUnitProject should parse .nunit project files containing Xml Declarations
+ * 1121 Usage of field set to null as value source leads to somewhat cryptic error
+ * 1122 Region may be disposed before test delegate is executed
+ * 1133 Provide a way to install extensions as nuget packages
+ * 1136 Don't allow V2 framework to update in V2 driver tests
+ * 1171 A bug when using Assert.That() with Is.Not.Empty
+ * 1185 Engine finds .NET 4.0 Client Profile twice
+ * 1187 ITestAssemblyRunner.StopRun as implemented by NUnitTestAssemblyRunner
+ * 1195 name attribute in test-suite and test-results element of output xml is different to nunit 2.6.4 using nunit2-format
+ * 1196 Custom value formatter for v3 via MsgUtils
+ * 1210 Available runtimes issues
+ * 1230 Add ability for testcasedatasource to have parameters passed to methods
+ * 1233 Add TestAssemblyRunner tests to both portable and silverlight builds
+ * 1234 Have default NUnitLite Runner Program.cs return exit code
+ * 1236 Make Appveyor NuGet feed more useable
+ * 1246 Introduce Is.Zero syntax to test for zero
+ * 1252 Exception thrown when any assembly is not found
+ * 1261 TypeHelper.GetDisplayName generates the wrong name for generic types with nested classes
+ * 1278 Fix optional parameters in TestCaseAttribute
+ * 1282 TestCase using Params Behaves Oddly
+ * 1283 Engine should expose available frameworks.
+ * 1286 value of the time attribute in nunit2 outputs depends on the machine culture
+ * 1297 NUnit.Engine nuget package improvements
+ * 1301 Assert.AreNotSame evaluates ToString unnecessarily
+
+NUnit 3.0.1 - December 1, 2015
+
+Console Runner
+
+ * The Nunit.Runners NuGet package was updated to become a meta-package that pulls in the NUnit.Console package
+ * Reinstated the --pause command line option that will display a message box allowing you to attach a debugger if the --debug option does not work
+
+Issues Resolved
+
+ * 994 Add max number of Agents to the NUnit project file
+ * 1014 Ensure NUnit API assembly updates with MSI installs
+ * 1024 Added --pause flag to console runner
+ * 1030 Update Nunit.Runners package to 3.0
+ * 1033 "No arguments were provided" with Theory and Values combination
+ * 1035 Check null arguments
+ * 1037 Async tests not working on Windows 10 Universal
+ * 1041 NUnit2XmlResult Writer is reporting Sucess when test fails
+ * 1042 NUnit2 reports on 3.0 is different than 2.6.4
+ * 1046 FloatingPointNumerics.AreAlmostEqualUlps throws OverflowException
+ * 1049 Cannot select Generic tests from command line
+ * 1050 Do not expose System.Runtime.CompilerServices.ExtensionAttribute to public
+ * 1054 Create nuget feeds for CI builds on Appveyor
+ * 1055 nunit3 console runner --where option does not return error on invalid selection string
+ * 1060 Remove "Version 3" from NUnit Nuget Package
+ * 1061 Nunit30Settings.xml becomes corrupted
+ * 1062 Console.WriteLine statements in "OneTimeSetUp" and "OneTimeTearDown" annotated methods are not directed to the console when using nunit3-console.exe runner
+ * 1063 Error in Random Test
+
+NUnit 3.0.0 Final Release - November 15, 2015
+
+Issues Resolved
+
+ * 635 Mono 4.0 Support
+
+NUnit 3.0.0 Release Candidate 3 - November 13, 2015
+
+Engine
+
+ * The engine now only sets the config file for project.nunit to project.config if project.config exists. Otherwise, each assembly uses its own config, provided it is run in a separate AppDomain by itself.
+
+   NOTE: It is not possible for multiple assemblies in the same AppDomain to use different configs. This is not an NUnit limitation, it's just how configs work!
+
+Issues Resolved
+
+ * 856 Extensions support for third party runners in NUnit 3.0
+ * 1003 Delete TeamCityEventHandler as it is not used
+ * 1015 Specifying .nunit project and --framework on command line causes crash
+ * 1017 Remove Assert.Multiple from framework
+
+NUnit 3.0.0 Release Candidate 2 - November 8, 2015
+
+Engine
+
+ * The IDriverFactory extensibility interface has been modified.
+
+Issues Resolved
+
+ * 970  Define PARALLEL in CF build of nunitlite
+ * 978  It should be possible to determine version of NUnit using nunit console tool
+ * 983  Inconsistent return codes depending on ProcessModel
+ * 986  Update docs for parallel execution
+ * 988  Don't run portable tests from NUnit Console
+ * 990  V2 driver is passing invalid filter elements to NUnit
+ * 991  Mono.Options should not be exposed to public directly
+ * 993  Give error message when a regex filter is used with NUnit V2
+ * 997  Add missing XML Documentation
+ * 1008 NUnitLite namespace not updated in the NuGet Packages
+
+NUnit 3.0.0 Release Candidate - November 1, 2015
+
+Framework
+
+ * The portable build now supports ASP.NET 5 and the new Core CLR.
+
+   NOTE: The `nunit3-console` runner cannot run tests that reference the portable build.
+   You may run such tests using NUnitLite or a platform-specific runner.
+
+ * `TestCaseAttribute` and `TestCaseData` now allow modifying the test name without replacing it entirely.
+ * The Silverlight packages are now separate downloads.
+
+NUnitLite
+
+ * The NUnitLite runner now produces the same output display and XML results as the console runner.
+
+Engine
+
+ * The format of the XML result file has been finalized and documented.
+
+Console Runner
+
+ * The console runner program is now called `nunit3-console`.
+ * Console runner output has been modified so that the summary comes at the end, to reduce the need for scrolling.
+
+Issues Resolved
+
+ *  59 Length of generated test names should be limited
+ *  68 Customization of test case name generation
+ * 404 Split tests between nunitlite.runner and nunit.framework
+ * 575 Add support for ASP.NET 5 and the new Core CLR
+ * 783 Package separately for Silverlight
+ * 833 Intermittent failure of WorkItemQueueTests.StopQueue_WithWorkers
+ * 859 NUnit-Console output - move Test Run Summary to end
+ * 867 Remove Warnings from Ignored tests
+ * 868 Review skipped tests
+ * 887 Move environment and settings elements to the assembly suite in the result file
+ * 899 Colors for ColorConsole on grey background are too light
+ * 904 InternalPreserveStackTrace is not supported on all Portable platforms
+ * 914 Unclear error message from console runner when assembly has no tests
+ * 916 Console runner dies when test agent dies
+ * 918 Console runner --where parameter is case sensitive
+ * 920 Remove addins\nunit.engine.api.dll from NuGet package
+ * 929 Rename nunit-console.exe
+ * 931 Remove beta warnings from NuGet packages
+ * 936 Explicit skipped tests not displayed
+ * 939 Installer complains about .NET even if already installed
+ * 940 Confirm or modify list of packages for release
+ * 947 Breaking API change in ValueSourceAttribute
+ * 949 Update copyright in NUnit Console
+ * 954 NUnitLite XML output is not consistent with the engine's
+ * 955 NUnitLite does not display the where clause
+ * 959 Restore filter options for NUnitLite portable build
+ * 960 Intermittent failure of CategoryFilterTests
+ * 967 Run Settings Report is not being displayed.
+
+NUnit 3.0.0 Beta 5 - October 16, 2015
+
+Framework
+
+ * Parameterized test cases now support nullable arguments.
+ * The NUnit framework may now be built for the .NET Core framework. Note that this is only available through building the source code. A binary will be available in the next release.
+
+Engine
+
+ * The engine now runs multiple test assemblies in parallel by default
+ * The output XML now includes more information about the test run, including the text of the command used, any engine settings and the filter used to select tests.
+ * Extensions may now specify data in an identifying attribute, for use by the engine in deciding whether to load that extension.
+
+
+Console Runner
+
+ * The console now displays all settings used by the engine to run tests as well as the filter used to select tests.
+ * The console runner accepts a new option --maxagents. If multiple assemblies are run in separate processes, this value may be used to limit the number that are executed simultaneously in parallel.
+ * The console runner no longer accepts the --include and --exclude options. Instead, the new --where option provides a more general way to express which tests will be executed, such as --where "cat==Fast && Priority==High". See the docs for details of the syntax.
+ * The new --debug option causes NUnit to break in the debugger immediately before tests are run. This simplifies debugging, especially when the test is run in a separate process.
+
+Issues Resolved
+
+ *  41	Check for zeroes in Assert messages
+ * 254	Finalize XML format for test results
+ * 275	NUnitEqualityComparer fails to compare IEquatable<T> where second object is derived from T
+ * 304	Run test Assemblies in parallel
+ * 374	New syntax for selecting tests to be run
+ * 515	OSPlatform.IsMacOSX doesn't work
+ * 573	nunit-console hangs on Mac OS X after all tests have run
+ * 669	TeamCity service message should have assembly name as a part of test name.
+ * 689	The TeamCity service message "testFinished" should have an integer value in the "duration" attribute
+ * 713	Include command information in XML
+ * 719	We have no way to configure tests for several assemblies using NUnit project file and the common installation from msi file
+ * 735	Workers number in xml report file cannot be found
+ * 784	Build Portable Framework on Linux
+ * 790	Allow Extensions to provide data through an attribute
+ * 794	Make it easier to debug tests as well as NUnit itself
+ * 801	NUnit calls Dispose multiple times
+ * 814	Support nullable types with TestCase
+ * 818	Possible error in Merge Pull Request #797
+ * 821	Wrapped method results in loss of result information
+ * 822	Test for Debugger in NUnitTestAssemblyRunner probably should not be in CF build
+ * 824	Remove unused System.Reflection using statements
+ * 826	Randomizer uniqueness tests fail randomly!
+ * 828	Merge pull request #827 (issue 826)
+ * 830	Add ability to report test results synchronously to test runners
+ * 837	Enumerators not disposed when comparing IEnumerables
+ * 840	Add missing copyright notices
+ * 844	Pull Request #835 (Issue #814) does not build in CF
+ * 847	Add new --process:inprocess and --inprocess options
+ * 850	Test runner fails if test name contains invalid xml characters
+ * 851	'Exclude' console option is not working in NUnit Lite
+ * 853	Cannot run NUnit Console from another directory
+ * 860	Use CDATA section for message, stack-trace and output elements of XML
+ * 863	Eliminate core engine
+ * 865	Intermittent failures of StopWatchTests
+ * 869	Tests that use directory separator char to determine platform misreport Linux on MaxOSX
+ * 870	NUnit Console Runtime Environment misreports on MacOSX
+ * 874	Add .NET Core Framework
+ * 878	Cannot exclude MacOSX or XBox platforms when running on CF
+ * 892	Fixed test runner returning early when executing more than one test run.
+ * 894	Give nunit.engine and nunit.engine.api assemblies strong names
+ * 896	NUnit 3.0 console runner not placing test result xml in --work directory
+
+NUnit 3.0.0 Beta 4 - August 25, 2015
+
+Framework
+
+ * A new RetryAttribute allows retrying of failing tests.
+ * New SupersetConstraint and Is.SupersetOf syntax complement SubsetConstraint.
+ * Tests skipped due to ExplicitAttribute are now reported as skipped.
+
+Engine
+
+ * We now use Cecil to examine assemblies prior to loading them.
+ * Extensions are no longer based on Mono.Addins but use our own extension framework.
+
+Issues Resolved
+
+ * 125 3rd-party dependencies should be downloaded on demand
+ * 283 What should we do when a user extension does something bad?
+ * 585 RetryAttribute
+ * 642 Restructure MSBuild script
+ * 649 Change how we zip packages
+ * 654 ReflectionOnlyLoad and ReflectionOnlyLoadFrom
+ * 664 Invalid "id" attribute in the report for case "test started"
+ * 685 In the some cases when tests cannot be started NUnit returns exit code "0"
+ * 728 Missing Assert.That overload
+ * 741 Explicit Tests get run when using --exclude
+ * 746 Framework should send events for all tests
+ * 747 NUnit should apply attributes even if test is non-runnable
+ * 749 Review Use of Mono.Addins for Engine Extensibility
+ * 750 Include Explicit Tests in Test Results
+ * 753 Feature request: Is.SupersetOf() assertion constraint
+ * 755 TimeOut attribute doesn't work with TestCaseSource Attribute
+ * 757 Implement some way to wait for execution to complete in ITestEngineRunner
+ * 760 Packaging targets do not run on Linux
+ * 766 Added overloads for True()/False() accepting booleans
+ * 778 Build and build.cmd scripts invoke nuget.exe improperly
+ * 780 Teamcity fix
+ * 782 No sources for 2.6.4
+
+NUnit 3.0.0 Beta 3 - July 15, 2015
+
+Framework
+
+ * The RangeAttribute has been extended to support more data types including
+   uint, long and ulong
+ * Added platform support for Windows 10 and fixed issues with Windows 8 and
+   8.1 support
+ * Added async support to the portable version of NUnit Framework
+ * The named members of the TestCaseSource and ValueSource attributes must now be
+   static.
+ * RandomAttribute has been extended to add support for new data types including
+   uint, long, ulong, short, ushort, float, byte and sbyte
+ * TestContext.Random has also been extended to add support for new data types including
+   uint, long, ulong, short, ushort, float, byte, sbyte and decimal
+ * Removed the dependency on Microsoft.Bcl.Async from the NUnit Framework assembly
+   targeting .NET 4.0. If you want to write async tests in .NET 4.0, you will need
+   to reference the NuGet package yourself.
+ * Added a new TestFixtureSource attribute which is the equivalent to TestCaseSource
+   but provides for instantiation of fixtures.
+ * Significant improvements have been made in how NUnit deduces the type arguments of
+   generic methods based on the arguments provided.
+
+Engine
+
+ * If the target framework is not specified, test assemblies that are compiled
+   to target .NET 4.5 will no longer run in .NET 4.0 compatibility mode
+
+ Console
+
+ * If the console is run without arguments, it will now display help
+
+Issues Resolved
+
+ *  47 Extensions to RangeAttribute
+ * 237 System.Uri .ctor works not properly under Nunit
+ * 244 NUnit should properly distinguish between .NET 4.0 and 4.5
+ * 310 Target framework not specified on the AppDomain when running against .Net 4.5
+ * 321 Rationalize how we count tests
+ * 472 Overflow exception and DivideByZero exception from the RangeAttribute
+ * 524 int and char do not compare correctly?
+ * 539 Truncation of string arguments
+ * 544 AsyncTestMethodTests for 4.5 Framework fails frequently on Travis CI
+ * 656 Unused parameter in Console.WriteLine found
+ * 670 Failing Tests in TeamCity Build
+ * 673 Ensure proper disposal of engine objects
+ * 674 Engine does not release test assemblies
+ * 679 Windows 10 Support
+ * 682 Add Async Support to Portable Framework
+ * 683 Make FrameworkController available in portable build
+ * 687 TestAgency does not launch agent process correctly if runtime type is not specified (i.e. v4.0)
+ * 692 PlatformAttribute_OperatingSystemBitNess fails when running in 32-bit process
+ * 693 Generic Test<T> Method cannot determine type arguments for fixture when passed as IEnumerable<T>
+ * 698 Require TestCaseSource and ValueSource named members to be static
+ * 703 TeamCity non-equal flowid for 'testStarted' and 'testFinished' messages
+ * 712 Extensions to RandomAttribute
+ * 715 Provide a data source attribute at TestFixture Level
+ * 718 RangeConstraint gives error with from and two args of differing types
+ * 723 Does nunit.nuspec require dependency on Microsoft.Bcl.Async?
+ * 724 Adds support for Nullable<bool> to Assert.IsTrue and Assert.IsFalse
+ * 734 Console without parameters doesn't show help
+
+NUnit 3.0.0 Beta 2 - May 12, 2015
+
+Framework
+
+ * The Compact Framework version of the framework is now packaged separately
+   and will be distributed as a ZIP file and as a NuGet package.
+ * The NUnit 2.x RepeatAttribute was added back into the framework.
+ * Added Throws.ArgumentNullException
+ * Added GetString methods to NUnit.Framework.Internal.RandomGenerator to
+   create repeatable random strings for testing
+ * When checking the equality of DateTimeOffset, you can now use the
+   WithSameOffset modifier
+ * Some classes intended for internal usage that were public for testing
+   have now been made internal. Additional classes will be made internal
+   for the final 3.0 release.
+
+Engine
+
+ * Added a core engine which is a non-extensible, minimal engine for use by
+   devices and similar situations where reduced functionality is compensated
+   for by reduced size and simplicity of usage. See
+   https://github.com/nunit/dev/wiki/Core-Engine for more information.
+
+Issues Resolved
+
+ *  22  Add OSArchitecture Attribute to Environment node in result xml
+ *  24  Assert on Dictionary Content
+ *  48  Explicit seems to conflict with Ignore
+ * 168  Create NUnit 3.0 documentation
+ * 196  Compare DateTimeOffsets including the offset in the comparison
+ * 217  New icon for the 3.0 release
+ * 316  NUnitLite TextUI Runner
+ * 320	No Tests found: Using parametrized Fixture and TestCaseSource
+ * 360  Better exception message when using non-BCL class in property
+ * 454  Rare registry configurations may cause NUnit to fail
+ * 478  RepeatAttribute
+ * 481  Testing multiple assemblies in nunitlite
+ * 538  Potential bug using TestContext in constructors
+ * 546  Enable Parallel in NUnitLite/CF (or more) builds
+ * 551  TextRunner not passing the NumWorkers option to the ITestAssemblyRunner
+ * 556  Executed tests should always return a non-zero duration
+ * 559  Fix text of NuGet packages
+ * 560  Fix PackageVersion property on wix install projects
+ * 562  Program.cs in NUnitLite NuGet package is incorrect
+ * 564  NUnitLite Nuget package is Beta 1a, Framework is Beta 1
+ * 565  NUnitLite Nuget package adds Program.cs to a VB Project
+ * 568  Isolate packaging from building
+ * 570  ThrowsConstraint failure message should include stack trace of actual exception
+ * 576  Throws.ArgumentNullException would be nice
+ * 577  Documentation on some members of Throws falsely claims that they return `TargetInvocationException` constraints
+ * 579  No documentation for recommended usage of TestCaseSourceAttribute
+ * 580  TeamCity Service Message Uses Incorrect Test Name with NUnit2Driver
+ * 582  Test Ids Are Not Unique
+ * 583  TeamCity service messages to support parallel test execution
+ * 584  Non-runnable assembly has incorrect ResultState
+ * 609  Add support for integration with TeamCity
+ * 611  Remove unused --teamcity option from CF build of NUnitLite
+ * 612  MaxTime doesn't work when used for TestCase
+ * 621  Core Engine
+ * 622  nunit-console fails when use --output
+ * 628  Modify IService interface and simplify ServiceContext
+ * 631  Separate packaging for the compact framework
+ * 646  ConfigurationManager.AppSettings Params Return Null under Beta 1
+ * 648  Passing 2 or more test assemblies targeting > .NET 2.0 to nunit-console fails
+
+NUnit 3.0.0 Beta 1 - March 25, 2015
+
+General
+
+ * There is now a master windows installer for the framework, engine and console runner.
+
+Framework
+
+ * We no longer create a separate framework build for .NET 3.5. The 2.0 and
+   3.5 builds were essentially the same, so the former should now be used
+   under both runtimes.
+ * A new Constraint, DictionaryContainsKeyConstraint, may be used to test
+   that a specified key is present in a dictionary.
+ * LevelOfParallelizationAttribute has been renamed to LevelOfParallelismAttribute.
+ * The Silverlight runner now displays output in color and includes any
+   text output created by the tests.
+ * The class and method names of each test are included in the output xml
+   where applicable.
+ * String arguments used in test case names are now truncated to 40 rather
+   than 20 characters.
+
+Engine
+
+ * The engine API has now been finalized. It permits specifying a minimum
+   version of the engine that a runner is able to use. The best installed
+   version of the engine will be loaded. Third-party runners may override
+   the selection process by including a copy of the engine in their
+   installation directory and specifying that it must be used.
+ * The V2 framework driver now uses the event listener and test listener
+   passed to it by the runner. This corrects several outstanding issues
+   caused by events not being received and allows selecting V2 tests to
+   be run from the command-line, in the same way that V3 tests are selected.
+
+Console
+
+ * The console now defaults to not using shadowcopy. There is a new option
+   --shadowcopy to turn it on if needed.
+
+Issues Resolved
+
+ * 224	Silverlight Support
+ * 318	TestActionAttribute: Retrieving the TestFixture
+ * 428	Add ExpectedExceptionAttribute to C# samples
+ * 440	Automatic selection of Test Engine to use
+ * 450	Create master install that includes the framework, engine and console installs
+ * 477	Assert does not work with ArraySegment
+ * 482	nunit-console has multiple errors related to -framework option
+ * 483	Adds constraint for asserting that a dictionary contains a particular key
+ * 484	Missing file in NUnit.Console nuget package
+ * 485	Can't run v2 tests with nunit-console 3.0
+ * 487	NUnitLite can't load assemblies by their file name
+ * 488	Async setup and teardown still don't work
+ * 497	Framework installer shold register the portable framework
+ * 504	Option --workers:0 is ignored
+ * 508	Travis builds with failure in engine tests show as successful
+ * 509	Under linux, not all mono profiles are listed as available
+ * 512	Drop the .NET 3.5 build
+ * 517	V2 FrameworkDriver does not make use of passed in TestEventListener
+ * 523	Provide an option to disable shadowcopy in NUnit v3
+ * 528	V2 FrameworkDriver does not make use of passed in TestFilter
+ * 530	Color display for Silverlight runner
+ * 531	Display text output from tests in Silverlight runner
+ * 534	Add classname and methodname to test result xml
+ * 541	Console help doesn't indicate defaults
+
+NUnit 3.0.0 Alpha 5 - January 30, 2015
+
+General
+
+ * A Windows installer is now included in the release packages.
+
+Framework
+
+ * TestCaseAttribute now allows arguments with default values to be omitted. Additionaly, it accepts a Platform property to specify the platforms on which the test case should be run.
+ * TestFixture and TestCase attributes now enforce the requirement that a reason needs to be provided when ignoring a test.
+ * SetUp, TearDown, OneTimeSetUp and OneTimeTearDown methods may now be async.
+ * String arguments over 20 characters in length are truncated when used as part of a test name.
+
+Engine
+
+ * The engine is now extensible using Mono.Addins. In this release, extension points are provided for FrameworkDrivers, ProjectLoaders and OutputWriters. The following addins are bundled as a part of NUnit:
+   * A FrameworkDriver that allows running NUnit V2 tests under NUnit 3.0.
+   * ProjectLoaders for NUnit and Visual Studio projects.
+   * An OutputWriter that creates XML output in NUnit V2 format.
+ * DomainUsage now defaults to Multiple if not specified by the runner
+
+Console
+
+ * New options supported:
+   * --testlist provides a list of tests to run in a file
+   * --stoponerror indicates that the run should terminate when any test fails.
+
+Issues Resolved
+
+ * 20 TestCaseAttribute needs Platform property.
+ * 60 NUnit should support async setup, teardown, fixture setup and fixture teardown.
+ * 257  TestCaseAttribute should not require parameters with default values to be specified.
+ * 266  Pluggable framework drivers.
+ * 368  Create addin model.
+ * 369  Project loader addins
+ * 370  OutputWriter addins
+ * 403  Move ConsoleOptions.cs and Options.cs to Common and share...
+ * 419  Create Windows Installer for NUnit.
+ * 427  [TestFixture(Ignore=true)] should not be allowed.
+ * 437  Errors in tests under Linux due to hard-coded paths.
+ * 441  NUnit-Console should support --testlist option
+ * 442  Add --stoponerror option back to nunit-console.
+ * 456  Fix memory leak in RuntimeFramework.
+ * 459  Remove the Mixed Platforms build configuration.
+ * 468  Change default domain usage to multiple.
+ * 469  Truncate string arguments in test names in order to limit the length.
+
+NUnit 3.0.0 Alpha 4 - December 30, 2014
+
+Framework
+
+ * ApartmentAttribute has been added, replacing STAAttribute and MTAAttribute.
+ * Unnecessary overloads of Assert.That and Assume.That have been removed.
+ * Multiple SetUpFixtures may be specified in a single namespace.
+ * Improvements to the Pairwise strategy test case generation algorithm.
+ * The new NUnitLite runner --testlist option, allows a list of tests to be kept in a file.
+
+Engine
+
+ * A driver is now included, which allows running NUnit 2.x tests under NUnit 3.0.
+ * The engine can now load and run tests specified in a number of project formats:
+   * NUnit (.nunit)
+   * Visual Studio C# projects (.csproj)
+   * Visual Studio F# projects (.vjsproj)
+   * Visual Studio Visual Basic projects (.vbproj)
+   * Visual Studio solutions (.sln)
+   * Legacy C++ and Visual JScript projects (.csproj and .vjsproj) are also supported
+   * Support for the current C++ format (.csxproj) is not yet available
+ * Creation of output files like TestResult.xml in various formats is now a
+   service of the engine, available to any runner.
+
+Console
+
+ * The command-line may now include any number of assemblies and/or supported projects.
+
+Issues Resolved
+
+ * 37	Multiple SetUpFixtures should be permitted on same namespace
+ * 210	TestContext.WriteLine in an AppDomain causes an error
+ * 227	Add support for VS projects and solutions
+ * 231	Update C# samples to use NUnit 3.0
+ * 233	Update F# samples to use NUnit 3.0
+ * 234	Update C++ samples to use NUnit 3.0
+ * 265	Reorganize console reports for nunit-console and nunitlite
+ * 299	No full path to assembly in XML file under Compact Framework
+ * 301	Command-line length
+ * 363	Make Xml result output an engine service
+ * 377	CombiningStrategyAttributes don't work correctly on generic methods
+ * 388	Improvements to NUnitLite runner output
+ * 390	Specify exactly what happens when a test times out
+ * 396	ApartmentAttribute
+ * 397	CF nunitlite runner assembly has the wrong name
+ * 407	Assert.Pass() with ]]> in message crashes console runner
+ * 414	Simplify Assert overloads
+ * 416	NUnit 2.x Framework Driver
+ * 417	Complete work on NUnit projects
+ * 420	Create Settings file in proper location
+
+NUnit 3.0.0 Alpha 3 - November 29, 2014
+
+Breaking Changes
+
+ * NUnitLite tests must reference both the nunit.framework and nunitlite assemblies.
+
+Framework
+
+ * The NUnit and NUnitLite frameworks have now been merged. There is no longer any distinction
+   between them in terms of features, although some features are not available on all platforms.
+ * The release includes two new framework builds: compact framework 3.5 and portable. The portable
+   library is compatible with .NET 4.5, Silverlight 5.0, Windows 8, Windows Phone 8.1,
+   Windows Phone Silverlight 8, Mono for Android and MonoTouch.
+ * A number of previously unsupported features are available for the Compact Framework:
+    - Generic methods as tests
+    - RegexConstraint
+    - TimeoutAttribute
+    - FileAssert, DirectoryAssert and file-related constraints
+
+Engine
+
+ * The logic of runtime selection has now changed so that each assembly runs by default
+   in a separate process using the runtime for which it was built.
+ * On 64-bit systems, each test process is automatically created as 32-bit or 64-bit,
+   depending on the platform specified for the test assembly.
+
+Console
+
+ * The console runner now runs tests in a separate process per assembly by default. They may
+   still be run in process or in a single separate process by use of command-line options.
+ * The console runner now starts in the highest version of the .NET runtime available, making
+   it simpler to debug tests by specifying that they should run in-process on the command-line.
+ * The -x86 command-line option is provided to force execution in a 32-bit process on a 64-bit system.
+ * A writeability check is performed for each output result file before trying to run the tests.
+ * The -teamcity option is now supported.
+
+Issues Resolved
+
+ * 12   Compact framework should support generic methods
+ * 145  NUnit-console fails if test result message contains invalid xml characters
+ * 155  Create utility classes for platform-specific code
+ * 223  Common code for NUnitLite console runner and NUnit-Console
+ * 225  Compact Framework Support
+ * 238  Improvements to running 32 bit tests on a 64 bit system
+ * 261  Add portable nunitlite build
+ * 284  NUnitLite Unification
+ * 293  CF does not have a CurrentDirectory
+ * 306  Assure NUnit can write resultfile
+ * 308  Early disposal of runners
+ * 309  NUnit-Console should support incremental output under TeamCity
+ * 325  Add RegexConstraint to compact framework build
+ * 326  Add TimeoutAttribute to compact framework build
+ * 327  Allow generic test methods in the compact framework
+ * 328  Use .NET Stopwatch class for compact framework builds
+ * 331  Alpha 2 CF does not build
+ * 333  Add parallel execution to desktop builds of NUnitLite
+ * 334  Include File-related constraints and syntax in NUnitLite builds
+ * 335  Re-introduce 'Classic' NUnit syntax in NUnitLite
+ * 336  Document use of separate obj directories per build in our projects
+ * 337  Update Standard Defines page for .NET 3.0
+ * 341  Move the NUnitLite runners to separate assemblies
+ * 367  Refactor XML Escaping Tests
+ * 372  CF Build TestAssemblyRunnerTests
+ * 373  Minor CF Test Fixes
+ * 378  Correct documentation for PairwiseAttribute
+ * 386  Console Output Improvements
+
+NUnit 3.0.0 Alpha 2 - November 2, 2014
+
+Breaking Changes
+
+ * The console runner no longer displays test results in the debugger.
+ * The NUnitLite compact framework 2.0 build has been removed.
+ * All addin support has been removed from the framework. Documentation of NUnit 3.0 extensibility features will be published in time for the beta release. In the interim, please ask for support on the nunit-discuss list.
+
+General
+
+ * A separate solution has been created for Linux
+ * We now have continuous integration builds under both Travis and Appveyor
+ * The compact framework 3.5 build is now working and will be supported in future releases.
+
+New Features
+
+ * The console runner now automatically detects 32- versus 64-bit test assemblies.
+ * The NUnitLite report output has been standardized to match that of nunit-console.
+ * The NUnitLite command-line has been standardized to match that of nunit-console where they share the same options.
+ * Both nunit-console and NUnitLite now display output in color.
+ * ActionAttributes now allow specification of multiple targets on the attribute as designed. This didn't work in the first alpha.
+ * OneTimeSetUp and OneTimeTearDown failures are now shown on the test report. Individual test failures after OneTimeSetUp failure are no longer shown.
+ * The console runner refuses to run tests build with older versions of NUnit. A plugin will be available to run older tests in the future.
+
+Issues Resolved
+
+ * 222	Color console for NUnitLite
+ * 229	Timing failures in tests
+ * 241	Remove reference to Microslft BCL packages
+ * 243	Create solution for Linux
+ * 245	Multiple targets on action attributes not implemented
+ * 246	C++ tests do not compile in VS2013
+ * 247	Eliminate trace display when running tests in debug
+ * 255	Add new result states for more precision in where failures occur
+ * 256	ContainsConstraint break when used with AndConstraint
+ * 264	Stacktrace displays too many entries
+ * 269	Add manifest to nunit-console and nunit-agent
+ * 270	OneTimeSetUp failure results in too much output
+ * 271	Invalid tests should be treated as errors
+ * 274	Command line options should be case insensitive
+ * 276	NUnit-console should not reference nunit.framework
+ * 278	New result states (ChildFailure and SetupFailure) break NUnit2XmlOutputWriter
+ * 282	Get tests for NUnit2XmlOutputWriter working
+ * 288	Set up Appveyor CI build
+ * 290	Stack trace still displays too many items
+ * 315	NUnit 3.0 alpha: Cannot run in console on my assembly
+ * 319	CI builds are not treating test failures as failures of the build
+ * 322	Remove Stopwatch tests where they test the real .NET Stopwatch
+
+NUnit 3.0.0 Alpha 1 - September 22, 2014
+
+Breaking Changes
+
+ * Legacy suites are no longer supported
+ * Assert.NullOrEmpty is no longer supported (Use Is.Null.Or.Empty)
+
+General
+
+ * MsBuild is now used for the build rather than NAnt
+ * The framework test harness has been removed now that nunit-console is at a point where it can run the tests.
+
+New Features
+
+ * Action Attributes have been added with the same features as in NUnit 2.6.3.
+ * TestContext now has a method that allows writing to the XML output.
+ * TestContext.CurrentContext.Result now provides the error message and stack trace during teardown.
+ * Does prefix operator supplies several added constraints.
+
+Issues Resolved
+
+ * 6	Log4net not working with NUnit
+ * 13	Standardize commandline options for nunitlite runner
+ * 17	No allowance is currently made for nullable arguents in TestCase parameter conversions
+ * 33	TestCaseSource cannot refer to a parameterized test fixture
+ * 54	Store message and stack trace in TestContext for use in TearDown
+ * 111	Implement Changes to File, Directory and Path Assertions
+ * 112	Implement Action Attributes
+ * 156	Accessing multiple AppDomains within unit tests result in SerializationException
+ * 163	Add --trace option to NUnitLite
+ * 167	Create interim documentation for the alpha release
+ * 169	Design and implement distribution of NUnit packages
+ * 171	Assert.That should work with any lambda returning bool
+ * 175	Test Harness should return an error if any tests fail
+ * 180	Errors in Linux CI build
+ * 181	Replace NAnt with MsBuild / XBuild
+ * 183	Standardize commandline options for test harness
+ * 188	No output from NUnitLite when selected test is not found
+ * 189	Add string operators to Does prefix
+ * 193	TestWorkerTests.BusyExecutedIdleEventsCalledInSequence fails occasionally
+ * 197	Deprecate or remove Assert.NullOrEmpty
+ * 202	Eliminate legacy suites
+ * 203	Combine framework, engine and console runner in a single solution and repository
+ * 209	Make Ignore attribute's reason mandatory
+ * 215	Running 32-bit tests on a 64-bit OS
+ * 219	Teardown failures are not reported
+
+Console Issues Resolved (Old nunit-console project, now combined with nunit)
+
+ * 2	Failure in TestFixtureSetUp is not reported correctly
+ * 5	CI Server for nunit-console
+ * 6	System.NullReferenceException on start nunit-console-x86
+ * 21	NUnitFrameworkDriverTests fail if not run from same directory
+ * 24	'Debug' value for /trace option is deprecated in 2.6.3
+ * 38	Confusing Excluded categories output
+
+NUnit 2.9.7 - August 8, 2014
+
+Breaking Changes
+
+ * NUnit no longer supports void async test methods. You should use a Task return Type instead.
+ * The ExpectedExceptionAttribute is no longer supported. Use Assert.Throws() or Assert.That(..., Throws) instead for a more precise specification of where the exception is expected to be thrown.
+
+New Features
+
+ * Parallel test execution is supported down to the Fixture level. Use ParallelizableAttribute to indicate types that may be run in parallel.
+ * Async tests are supported for .NET 4.0 if the user has installed support for them.
+ * A new FileExistsConstraint has been added along with FileAssert.Exists and FileAssert.DoesNotExist
+ * ExpectedResult is now supported on simple (non-TestCase) tests.
+ * The Ignore attribute now takes a named parameter Until, which allows specifying a date after which the test is no longer ignored.
+ * The following new values are now recognized by PlatformAttribute: Win7, Win8, Win8.1, Win2012Server, Win2012ServerR2, NT6.1, NT6.2, 32-bit, 64-bit
+ * TimeoutAttribute is now supported under Silverlight
+ * ValuesAttribute may be used without any values on an enum or boolean argument. All possible values are used.
+ * You may now specify a tolerance using Within when testing equality of DateTimeOffset values.
+ * The XML output now includes a start and end time for each test.
+
+Issues Resolved
+
+ * 8	[SetUpFixture] is not working as expected
+ * 14	CI Server for NUnit Framework
+ * 21	Is.InRange Constraint Ambiguity
+ * 27	Values attribute support for enum types
+ * 29	Specifying a tolerance with "Within" doesn't work for DateTimeOffset data types
+ * 31	Report start and end time of test execution
+ * 36	Make RequiresThread, RequiresSTA, RequiresMTA inheritable
+ * 45	Need of Enddate together with Ignore
+ * 55	Incorrect XML comments for CollectionAssert.IsSubsetOf
+ * 62	Matches(Constraint) does not work as expected
+ * 63	Async support should handle Task return type without state machine
+ * 64	AsyncStateMachineAttribute should only be checked by name
+ * 65	Update NUnit Wiki to show the new location of samples
+ * 66	Parallel Test Execution within test assemblies
+ * 67	Allow Expected Result on simple tests
+ * 70	EquivalentTo isn't compatible with IgnoreCase for dictioneries
+ * 75	Async tests should be supported for projects that target .NET 4.0
+ * 82	nunit-framework tests are timing out on Linux
+ * 83	Path-related tests fail on Linux
+ * 85	Culture-dependent NUnit tests fail on non-English machine
+ * 88	TestCaseSourceAttribute documentation
+ * 90	EquivalentTo isn't compatible with IgnoreCase for char
+ * 100	Changes to Tolerance definitions
+ * 110	Add new platforms to PlatformAttribute
+ * 113	Remove ExpectedException
+ * 118	Workarounds for missing InternalPreserveStackTrace in mono
+ * 121	Test harness does not honor the --worker option when set to zero
+ * 129	Standardize Timeout in the Silverlight build
+ * 130	Add FileAssert.Exists and FileAssert.DoesNotExist
+ * 132	Drop support for void async methods
+ * 153	Surprising behavior of DelayedConstraint pollingInterval
+ * 161	Update API to support stopping an ongoing test run
+
+NOTE: Bug Fixes below this point refer to the number of the bug in Launchpad.
+
+NUnit 2.9.6 - October 4, 2013
+
+Main Features
+
+ * Separate projects for nunit-console and nunit.engine
+ * New builds for .NET 4.5 and Silverlight
+ * TestContext is now supported
+ * External API is now stable; internal interfaces are separate from API
+ * Tests may be run in parallel on separate threads
+ * Solutions and projects now use VS2012 (except for Compact framework)
+
+Bug Fixes
+
+ * 463470 	We should encapsulate references to pre-2.0 collections
+ * 498690 	Assert.That() doesn't like properties with scoped setters
+ * 501784 	Theory tests do not work correctly when using null parameters
+ * 531873 	Feature: Extraction of unit tests from NUnit test assembly and calling appropriate one
+ * 611325 	Allow Teardown to detect if last test failed
+ * 611938 	Generic Test Instances disappear
+ * 655882 	Make CategoryAttribute inherited
+ * 664081 	Add Server2008 R2 and Windows 7 to PlatformAttribute
+ * 671432 	Upgrade NAnt to Latest Release
+ * 676560 	Assert.AreEqual does not support IEquatable<T>
+ * 691129 	Add Category parameter to TestFixture
+ * 697069 	Feature request: dynamic location for TestResult.xml
+ * 708173 	NUnit's logic for comparing arrays - use Comparer<T[]> if it is provided
+ * 709062 	"System.ArgumentException : Cannot compare" when the element is a list
+ * 712156 	Tests cannot use AppDomain.SetPrincipalPolicy
+ * 719184 	Platformdependency in src/ClientUtilities/util/Services/DomainManager.cs:40
+ * 719187 	Using Path.GetTempPath() causes conflicts in shared temporary folders
+ * 735851 	Add detection of 3.0, 3.5 and 4.0 frameworks to PlatformAttribute
+ * 736062 	Deadlock when EventListener performs a Trace call + EventPump synchronisation
+ * 756843 	Failing assertion does not show non-linear tolerance mode
+ * 766749 	net-2.0\nunit-console-x86.exe.config should have a <startup /> element and also enable loadFromRemoteSources
+ * 770471 	Assert.IsEmpty does not support IEnumerable
+ * 785460 	Add Category parameter to TestCaseSourceAttribute
+ * 787106 	EqualConstraint provides inadequate failure information for IEnumerables
+ * 792466 	TestContext MethodName
+ * 794115 	HashSet incorrectly reported
+ * 800089 	Assert.Throws() hides details of inner AssertionException
+ * 848713 	Feature request: Add switch for console to break on any test case error
+ * 878376 	Add 'Exactly(n)' to the NUnit constraint syntax
+ * 882137 	When no tests are run, higher level suites display as Inconclusive
+ * 882517 	NUnit 2.5.10 doesn't recognize TestFixture if there are only TestCaseSource inside
+ * 885173 	Tests are still executed after cancellation by user
+ * 885277 	Exception when project calls for a runtime using only 2 digits
+ * 885604 	Feature request: Explicit named parameter to TestCaseAttribute
+ * 890129 	DelayedConstraint doesn't appear to poll properties of objects
+ * 892844 	Not using Mono 4.0 profile under Windows
+ * 893919 	DelayedConstraint fails polling properties on references which are initially null
+ * 896973 	Console output lines are run together under Linux
+ * 897289 	Is.Empty constraint has unclear failure message
+ * 898192 	Feature Request: Is.Negative, Is.Positive
+ * 898256 	IEnumerable<T> for Datapoints doesn't work
+ * 899178 	Wrong failure message for parameterized tests that expect exceptions
+ * 904841 	After exiting for timeout the teardown method is not executed
+ * 908829 	TestCase attribute does not play well with variadic test functions
+ * 910218 	NUnit should add a trailing separator to the ApplicationBase
+ * 920472 	CollectionAssert.IsNotEmpty must dispose Enumerator
+ * 922455 	Add Support for Windows 8 and Windows 2012 Server to PlatformAttribute
+ * 928246 	Use assembly.Location instead of assembly.CodeBase
+ * 958766 	For development work under TeamCity, we need to support nunit2 formatted output under direct-runner
+ * 1000181 	Parameterized TestFixture with System.Type as constructor arguments fails
+ * 1000213 	Inconclusive message Not in report output
+ * 1023084 	Add Enum support to RandomAttribute
+ * 1028188 	Add Support for Silverlight
+ * 1029785 	Test loaded from remote folder failed to run with exception System.IODirectory
+ * 1037144 	Add MonoTouch support to PlatformAttribute
+ * 1041365 	Add MaxOsX and Xbox support to platform attribute
+ * 1057981 	C#5 async tests are not supported
+ * 1060631 	Add .NET 4.5 build
+ * 1064014 	Simple async tests should not return Task<T>
+ * 1071164 	Support async methods in usage scenarios of Throws constraints
+ * 1071343 	Runner.Load fails on CF if the test assembly contains a generic method
+ * 1071861 	Error in Path Constraints
+ * 1072379 	Report test execution time at a higher resolution
+ * 1074568 	Assert/Assume should support an async method for the ActualValueDelegate
+ * 1082330 	Better Exception if SetCulture attribute is applied multiple times
+ * 1111834 	Expose Random Object as part of the test context
+ * 1111838 	Include Random Seed in Test Report
+ * 1172979 	Add Category Support to nunitlite Runner
+ * 1203361 	Randomizer uniqueness tests sometimes fail
+ * 1221712 	When non-existing test method is specified in -test, result is still "Tests run: 1, Passed: 1"
+ * 1223294 	System.NullReferenceException thrown when ExpectedExceptionAttribute is used in a static class
+ * 1225542 	Standardize commandline options for test harness
+
+Bug Fixes in 2.9.6 But Not Listed Here in the Release
+
+ * 541699	Silverlight Support
+ * 1222148	/framework switch does not recognize net-4.5
+ * 1228979	Theories with all test cases inconclusive are not reported as failures
+
+
+NUnit 2.9.5 - July 30, 2010
+
+Bug Fixes
+
+ * 483836 	Allow non-public test fixtures consistently
+ * 487878 	Tests in generic class without proper TestFixture attribute should be invalid
+ * 498656 	TestCase should show array values in GUI
+ * 513989 	Is.Empty should work for directories
+ * 519912 	Thread.CurrentPrincipal Set In TestFixtureSetUp Not Maintained Between Tests
+ * 532488 	constraints from ConstraintExpression/ConstraintBuilder are not reusable
+ * 590717 	categorie contains dash or trail spaces is not selectable
+ * 590970 	static TestFixtureSetUp/TestFixtureTearDown methods in base classes are not run
+ * 595683 	NUnit console runner fails to load assemblies
+ * 600627 	Assertion message formatted poorly by PropertyConstraint
+ * 601108 	Duplicate test using abstract test fixtures
+ * 601645 	Parametered test should try to convert data type from source to parameter
+ * 605432 	ToString not working properly for some properties
+ * 606548 	Deprecate Directory Assert in 2.5 and remove it in 3.0
+ * 608875 	NUnit Equality Comparer incorrectly defines equality for Dictionary objects
+
+NUnit 2.9.4 - May 4, 2010
+
+Bug Fixes
+
+ * 419411 	Fixture With No Tests Shows as Non-Runnable
+ * 459219 	Changes to thread princpal cause failures under .NET 4.0
+ * 459224 	Culture test failure under .NET 4.0
+ * 462019 	Line endings needs to be better controlled in source
+ * 462418 	Assume.That() fails if I specify a message
+ * 483845 	TestCase expected return value cannot be null
+ * 488002 	Should not report tests in abstract class as invalid
+ * 490679 	Category in TestCaseData clashes with Category on ParameterizedMethodSuite
+ * 501352 	VS2010 projects have not been updated for new directory structure
+ * 504018 	Automatic Values For Theory Test Parameters Not Provided For bool And enum
+ * 505899 	'Description' parameter in both TestAttribute and TestCaseAttribute is not allowed
+ * 523335 	TestFixtureTearDown in static class not executed
+ * 556971 	Datapoint(s)Attribute should work on IEnumerable<T> as well as on Arrays
+ * 561436 	SetCulture broken with 2.5.4
+ * 563532 	DatapointsAttribute should be allowed on properties and methods
+
+NUnit 2.9.3 - October 26, 2009
+
+Main Features
+
+ * Created new API for controlling framework
+ * New builds for .Net 3.5 and 4.0, compact framework 3.5
+ * Support for old style tests has been removed
+ * New adhoc runner for testing the framework
+
+Bug Fixes
+
+ * 432805 	Some Framework Tests don't run on Linux
+ * 440109 	Full Framework does not support "Contains"
+
+NUnit 2.9.2 - September 19, 2009
+
+Main Features
+
+ * NUnitLite code is now merged with NUnit
+ * Added NUnitLite runner to the framework code
+ * Added Compact framework builds
+
+Bug Fixes
+
+ * 430100 	Assert.Catch<T> should return T
+ * 432566 	NUnitLite shows empty string as argument
+ * 432573 	Mono test should be at runtime
+
+NUnit 2.9.1 - August 27, 2009
+
+General
+
+ * Created a separate project for the framework and framework tests
+ * Changed license to MIT / X11
+ * Created Windows installer for the framework
+
+Bug Fixes
+
+ * 400502 	NUnitEqualityComparer.StreamsE­qual fails for same stream
+ * 400508 	TestCaseSource attirbute is not working when Type is given
+ * 400510 	TestCaseData variable length ctor drops values
+ * 417557 	Add SetUICultureAttribute from NUnit 2.5.2
+ * 417559 	Add Ignore to TestFixture, TestCase and TestCaseData
+ * 417560 	Merge Assert.Throws and Assert.Catch changes from NUnit 2.5.2
+ * 417564 	TimeoutAttribute on Assembly

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/LICENSE.txt
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Charlie Poole, Rob Prouse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/NOTICES.txt
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/NOTICES.txt
@@ -1,0 +1,5 @@
+NUnit 3.0 is based on earlier versions of NUnit, with Portions
+
+Copyright (c) 2002-2014 Charlie Poole or 
+Copyright (c) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov or 
+Copyright (c) 2000-2002 Philip A. Craig

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit-agent-x86.exe.config
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit-agent-x86.exe.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+   Nunit-agent only runs under .NET 2.0 or higher. 
+   The setting    useLegacyV2RuntimeActivationPolicy only applies 
+   under .NET 4.0 and permits use of mixed mode assemblies, 
+   which would otherwise not load correctly. 
+  -->
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <!--
+     Nunit-agent is normally run by the console or gui
+     runners and not independently. In normal usage, 
+     the runner specifies which runtime should be used.
+     
+     Do NOT add any supportedRuntime elements here, 
+     since they may prevent the runner from controlling 
+     the runtime that is used!
+    -->
+  </startup>
+
+  <runtime>
+    <!-- Ensure that test exceptions don't crash NUnit -->
+    <legacyUnhandledExceptionPolicy enabled="1" />
+
+    <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
+    <loadFromRemoteSources enabled="true" />
+
+  </runtime>
+  
+</configuration>

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit-agent.exe.config
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit-agent.exe.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+   Nunit-agent only runs under .NET 2.0 or higher. 
+   The setting    useLegacyV2RuntimeActivationPolicy only applies 
+   under .NET 4.0 and permits use of mixed mode assemblies, 
+   which would otherwise not load correctly. 
+  -->
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <!--
+     Nunit-agent is normally run by the console or gui
+     runners and not independently. In normal usage, 
+     the runner specifies which runtime should be used.
+     
+     Do NOT add any supportedRuntime elements here, 
+     since they may prevent the runner from controlling 
+     the runtime that is used!
+    -->
+  </startup>
+
+  <runtime>
+    <!-- Ensure that test exceptions don't crash NUnit -->
+    <legacyUnhandledExceptionPolicy enabled="1" />
+
+    <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
+    <loadFromRemoteSources enabled="true" />
+
+  </runtime>
+  
+</configuration>

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit.engine.api.xml
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit.engine.api.xml
@@ -1,0 +1,1119 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>nunit.engine.api</name>
+    </assembly>
+    <members>
+        <member name="T:NUnit.Engine.Extensibility.TypeExtensionPointAttribute">
+            <summary>
+            TypeExtensionPointAttribute is used to bind an extension point
+            to a class or interface.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.TypeExtensionPointAttribute.#ctor(System.String)">
+            <summary>
+            Construct a TypeExtensionPointAttribute, specifying the path.
+            </summary>
+            <param name="path">A unique string identifying the extension point.</param>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.TypeExtensionPointAttribute.#ctor">
+            <summary>
+            Construct an TypeExtensionPointAttribute, without specifying the path.
+            The extension point will use a path constructed based on the interface
+            or class to which the attribute is applied.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.TypeExtensionPointAttribute.Path">
+            <summary>
+            The unique string identifying this ExtensionPoint. This identifier
+            is typically formatted as a path using '/' and the set of extension 
+            points is sometimes viewed as forming a tree.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.TypeExtensionPointAttribute.Description">
+            <summary>
+            An optional description of the purpose of the ExtensionPoint
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.ExtensionPropertyAttribute">
+            <summary>
+            The ExtensionPropertyAttribute is used to specify named properties for an extension.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.ExtensionPropertyAttribute.#ctor(System.String,System.String)">
+            <summary>
+            Construct an ExtensionPropertyAttribute
+            </summary>
+            <param name="name">The name of the property</param>
+            <param name="value">The property value</param>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionPropertyAttribute.Name">
+            <summary>
+            The name of the property.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionPropertyAttribute.Value">
+            <summary>
+            The property value
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.ExtensionAttribute">
+            <summary>
+            The ExtensionAttribute is used to identify a class that is intended
+            to serve as an extension.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.ExtensionAttribute.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:NUnit.Engine.Extensibility.ExtensionAttribute"/> class.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionAttribute.Path">
+            <summary>
+            A unique string identifying the ExtensionPoint for which this Extension is 
+            intended. This is an optional field provided NUnit is able to deduce the
+            ExtensionPoint from the Type of the extension class.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionAttribute.Description">
+            <summary>
+            An optional description of what the extension does.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionAttribute.Enabled">
+            <summary>
+            Flag indicating whether the extension is enabled.
+            </summary>
+            <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionAttribute.EngineVersion">
+            <summary>
+            The minimum Engine version for which this extension is designed
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.ExtensionPointAttribute">
+            <summary>
+            ExtensionPointAttribute is used at the assembly level to identify and
+            document any ExtensionPoints supported by the assembly.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.ExtensionPointAttribute.#ctor(System.String,System.Type)">
+            <summary>
+            Construct an ExtensionPointAttribute
+            </summary>
+            <param name="path">A unique string identifying the extension point.</param>
+            <param name="type">The required Type of any extension that is installed at this extension point.</param>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionPointAttribute.Path">
+            <summary>
+            The unique string identifying this ExtensionPoint. This identifier
+            is typically formatted as a path using '/' and the set of extension 
+            points is sometimes viewed as forming a tree.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionPointAttribute.Type">
+            <summary>
+            The required Type (usually an interface) of any extension that is 
+            installed at this ExtensionPoint.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.ExtensionPointAttribute.Description">
+            <summary>
+            An optional description of the purpose of the ExtensionPoint
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IDriverFactory">
+            <summary>
+            Interface implemented by a Type that knows how to create a driver for a test assembly.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IDriverFactory.IsSupportedTestFramework(System.Reflection.AssemblyName)">
+            <summary>
+            Gets a flag indicating whether a given AssemblyName
+            represents a test framework supported by this factory.
+            </summary>
+            <param name="reference">An AssemblyName referring to the possible test framework.</param>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IDriverFactory.GetDriver(System.AppDomain,System.Reflection.AssemblyName)">
+            <summary>
+            Gets a driver for a given test assembly and a framework
+            which the assembly is already known to reference.
+            </summary>
+            <param name="domain">The domain in which the assembly will be loaded</param>
+            <param name="reference">An AssemblyName referring to the test framework.</param>
+            <returns></returns>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IProject">
+            <summary>
+            Interface for the various project types that the engine can load.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IProject.ProjectPath">
+            <summary>
+            Gets the path to the file storing this project, if any.
+            If the project has not been saved, this is null.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IProject.ActiveConfigName">
+            <summary>
+            Gets the active configuration, as defined
+            by the particular project.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IProject.ConfigNames">
+            <summary>
+            Gets a list of the configs for this project
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IProject.GetTestPackage">
+            <summary>
+            Gets a test package for the primary or active
+            configuration within the project. The package 
+            includes all the assemblies and any settings
+            specified in the project format.
+            </summary>
+            <returns>A TestPackage</returns>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IProject.GetTestPackage(System.String)">
+            <summary>
+            Gets a TestPackage for a specific configuration
+            within the project. The package includes all the
+            assemblies and any settings specified in the 
+            project format.
+            </summary>
+            <param name="configName">The name of the config to use</param>
+            <returns>A TestPackage for the named configuration.</returns>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IProjectLoader">
+            <summary>
+            The IProjectLoader interface is implemented by any class
+            that knows how to load projects in a specific format.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IProjectLoader.CanLoadFrom(System.String)">
+            <summary>
+            Returns true if the file indicated is one that this
+            loader knows how to load.
+            </summary>
+            <param name="path">The path of the project file</param>
+            <returns>True if the loader knows how to load this file, otherwise false</returns>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IProjectLoader.LoadFrom(System.String)">
+            <summary>
+            Loads a project of a known format.
+            </summary>
+            <param name="path">The path of the project file</param>
+            <returns>An IProject interface to the loaded project or null if the project cannot be loaded</returns>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IResultWriter">
+            <summary>
+            Common interface for objects that process and write out test results
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IResultWriter.CheckWritability(System.String)">
+            <summary>
+            Checks if the output path is writable. If the output is not
+            writable, this method should throw an exception.
+            </summary>
+            <param name="outputPath"></param>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IResultWriter.WriteResultFile(System.Xml.XmlNode,System.String)">
+            <summary>
+            Writes result to the specified output path.
+            </summary>
+            <param name="resultNode">XmlNode for the result</param>
+            <param name="outputPath">Path to which it should be written</param>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IResultWriter.WriteResultFile(System.Xml.XmlNode,System.IO.TextWriter)">
+            <summary>
+            Writes result to a TextWriter.
+            </summary>
+            <param name="resultNode">XmlNode for the result</param>
+            <param name="writer">TextWriter to which it should be written</param>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IFrameworkDriver">
+            <summary>
+            The IFrameworkDriver interface is implemented by a class that
+            is able to use an external framework to explore or run tests
+            under the engine.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IFrameworkDriver.ID">
+            <summary>
+            Gets and sets the unique identifier for this driver,
+            used to ensure that test ids are unique across drivers.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IFrameworkDriver.Load(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
+            <summary>
+            Loads the tests in an assembly.
+            </summary>
+            <returns>An Xml string representing the loaded test</returns>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IFrameworkDriver.CountTestCases(System.String)">
+            <summary>
+            Count the test cases that would be executed.
+            </summary>
+            <param name="filter">An XML string representing the TestFilter to use in counting the tests</param>
+            <returns>The number of test cases counted</returns>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IFrameworkDriver.Run(NUnit.Engine.ITestEventListener,System.String)">
+            <summary>
+            Executes the tests in an assembly.
+            </summary>
+            <param name="listener">An ITestEventHandler that receives progress notices</param>
+            <param name="filter">A XML string representing the filter that controls which tests are executed</param>
+            <returns>An Xml string representing the result</returns>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IFrameworkDriver.Explore(System.String)">
+            <summary>
+            Returns information about the tests in an assembly.
+            </summary>
+            <param name="filter">An XML string representing the filter that controls which tests are included</param>
+            <returns>An Xml string representing the tests</returns>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IFrameworkDriver.StopRun(System.Boolean)">
+            <summary>
+            Cancel the ongoing test run. If no  test is running, the call is ignored.
+            </summary>
+            <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IExtensionPoint">
+            <summary>
+            An ExtensionPoint represents a single point in the TestEngine
+            that may be extended by user addins and extensions.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionPoint.Path">
+            <summary>
+            Gets the unique path identifying this extension point.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionPoint.Description">
+            <summary>
+            Gets the description of this extension point. May be null.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionPoint.TypeName">
+            <summary>
+            Gets the FullName of the Type required for any extension to be installed at this extension point.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionPoint.Extensions">
+            <summary>
+            Gets an enumeration of IExtensionNodes for extensions installed on this extension point.
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.Extensibility.IExtensionNode">
+            <summary>
+            The IExtensionNode interface is implemented by a class that represents a 
+            single extension being installed on a particular extension point.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionNode.TypeName">
+            <summary>
+            Gets the full name of the Type of the extension object.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionNode.Enabled">
+            <summary>
+            Gets a value indicating whether this <see cref="T:NUnit.Engine.Extensibility.IExtensionNode"/> is enabled.
+            </summary>
+            <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionNode.Path">
+            <summary>
+            Gets the unique string identifying the ExtensionPoint for which 
+            this Extension is intended. This identifier may be supplied by the attribute
+            marking the extension or deduced by NUnit from the Type of the extension class.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionNode.Description">
+            <summary>
+            Gets an optional description of what the extension does.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.Extensibility.IExtensionNode.PropertyNames">
+            <summary>
+            Gets a collection of the names of all this extension's properties
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.Extensibility.IExtensionNode.GetValues(System.String)">
+            <summary>
+            Gets a collection of the values of a particular named property
+            If none are present, returns an empty enumerator.
+            </summary>
+            <param name="name">The property name</param>
+            <returns>A collection of values</returns>
+        </member>
+        <member name="T:NUnit.Engine.ILogger">
+            <summary>
+            Interface for logging within the engine
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Error(System.String)">
+            <summary>
+            Logs the specified message at the error level.
+            </summary>
+            <param name="message">The message.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Error(System.String,System.Object[])">
+            <summary>
+            Logs the specified message at the error level.
+            </summary>
+            <param name="message">The message.</param>
+            <param name="args">The arguments.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Warning(System.String)">
+            <summary>
+            Logs the specified message at the warning level.
+            </summary>
+            <param name="message">The message.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Warning(System.String,System.Object[])">
+            <summary>
+            Logs the specified message at the warning level.
+            </summary>
+            <param name="message">The message.</param>
+            <param name="args">The arguments.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Info(System.String)">
+            <summary>
+            Logs the specified message at the info level.
+            </summary>
+            <param name="message">The message.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Info(System.String,System.Object[])">
+            <summary>
+            Logs the specified message at the info level.
+            </summary>
+            <param name="message">The message.</param>
+            <param name="args">The arguments.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Debug(System.String)">
+            <summary>
+            Logs the specified message at the debug level.
+            </summary>
+            <param name="message">The message.</param>
+        </member>
+        <member name="M:NUnit.Engine.ILogger.Debug(System.String,System.Object[])">
+            <summary>
+            Logs the specified message at the debug level.
+            </summary>
+            <param name="message">The message.</param>
+            <param name="args">The arguments.</param>
+        </member>
+        <member name="T:NUnit.Engine.InternalTraceLevel">
+            <summary>
+            InternalTraceLevel is an enumeration controlling the
+            level of detailed presented in the internal log.
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Default">
+            <summary>
+            Use the default settings as specified by the user.
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Off">
+            <summary>
+            Do not display any trace messages
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Error">
+            <summary>
+            Display Error messages only
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Warning">
+            <summary>
+            Display Warning level and higher messages
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Info">
+            <summary>
+            Display informational and higher messages
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Debug">
+            <summary>
+            Display debug messages and higher - i.e. all messages
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.InternalTraceLevel.Verbose">
+            <summary>
+            Display debug messages and higher - i.e. all messages
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.IRuntimeFramework">
+            <summary>
+            Interface implemented by objects representing a runtime framework.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRuntimeFramework.Id">
+            <summary>
+            Gets the inique Id for this runtime, such as "net-4.5"
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRuntimeFramework.DisplayName">
+            <summary>
+            Gets the display name of the framework, such as ".NET 4.5"
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRuntimeFramework.FrameworkVersion">
+            <summary>
+            Gets the framework version: usually contains two components, Major
+            and Minor, which match the corresponding CLR components, but not always.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRuntimeFramework.ClrVersion">
+            <summary>
+            Gets the Version of the CLR for this framework
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRuntimeFramework.Profile">
+            <summary>
+            Gets a string representing the particular profile installed,
+            or null if there is no profile. Currently. the only defined 
+            values are Full and Client.
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.IAvailableRuntimes">
+            <summary>
+            Interface that returns a list of available runtime frameworks.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IAvailableRuntimes.AvailableRuntimes">
+            <summary>
+            Gets a list of available runtime frameworks.
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.IResultService">
+            <summary>
+            IResultWriterService provides result writers for a specified
+            well-known format.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IResultService.Formats">
+            <summary>
+            Gets an array of the available formats
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IResultService.GetResultWriter(System.String,System.Object[])">
+            <summary>
+            Gets a ResultWriter for a given format and set of arguments.
+            </summary>
+            <param name="format">The name of the format to be used</param>
+            <param name="args">A set of arguments to be used in constructing the writer or null if non arguments are needed</param>
+            <returns>An IResultWriter</returns>
+        </member>
+        <member name="T:NUnit.Engine.IRuntimeFrameworkService">
+            <summary>
+            Implemented by a type that provides information about the
+            current and other available runtimes.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IRuntimeFrameworkService.IsAvailable(System.String)">
+            <summary>
+            Returns true if the runtime framework represented by
+            the string passed as an argument is available.
+            </summary>
+            <param name="framework">A string representing a framework, like 'net-4.0'</param>
+            <returns>True if the framework is available, false if unavailable or nonexistent</returns>
+        </member>
+        <member name="M:NUnit.Engine.IRuntimeFrameworkService.SelectRuntimeFramework(NUnit.Engine.TestPackage)">
+            <summary>
+            Selects a target runtime framework for a TestPackage based on
+            the settings in the package and the assemblies themselves.
+            The package RuntimeFramework setting may be updated as a 
+            result and the selected runtime is returned.
+            </summary>
+            <param name="package">A TestPackage</param>
+            <returns>The selected RuntimeFramework</returns>
+        </member>
+        <member name="T:NUnit.Engine.ServiceStatus">
+            <summary>
+            Enumeration representing the status of a service
+            </summary>
+        </member>
+        <member name="F:NUnit.Engine.ServiceStatus.Stopped">
+            <summary>Service was never started or has been stopped</summary>
+        </member>
+        <member name="F:NUnit.Engine.ServiceStatus.Started">
+            <summary>Started successfully</summary>
+        </member>
+        <member name="F:NUnit.Engine.ServiceStatus.Error">
+            <summary>Service failed to start and is unavailable</summary>
+        </member>
+        <member name="T:NUnit.Engine.IService">
+            <summary>
+            The IService interface is implemented by all Services. Although it
+            is extensible, it does not reside in the Extensibility namespace
+            because it is so widely used by the engine.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IService.ServiceContext">
+            <summary>
+            The ServiceContext
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IService.Status">
+            <summary>
+            Gets the ServiceStatus of this service
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IService.StartService">
+            <summary>
+            Initialize the Service
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IService.StopService">
+            <summary>
+            Do any cleanup needed before terminating the service
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.ITestFilterBuilder">
+            <summary>
+            Interface to a TestFilterBuilder, which is used to create TestFilters
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestFilterBuilder.AddTest(System.String)">
+            <summary>
+            Add a test to be selected
+            </summary>
+            <param name="fullName">The full name of the test, as created by NUnit</param>
+        </member>
+        <member name="M:NUnit.Engine.ITestFilterBuilder.SelectWhere(System.String)">
+            <summary>
+            Specify what is to be included by the filter using a where clause.
+            </summary>
+            <param name="whereClause">A where clause that will be parsed by NUnit to create the filter.</param>
+        </member>
+        <member name="M:NUnit.Engine.ITestFilterBuilder.GetFilter">
+            <summary>
+            Get a TestFilter constructed according to the criteria specified by the other calls.
+            </summary>
+            <returns>A TestFilter.</returns>
+        </member>
+        <member name="T:NUnit.Engine.ITestFilterService">
+            <summary>
+            The TestFilterService provides builders that can create TestFilters
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestFilterService.GetTestFilterBuilder">
+            <summary>
+            Get an uninitialized TestFilterBuilder
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.NUnitEngineNotFoundException">
+            <summary>
+            The exception that is thrown if a valid test engine is not found
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.NUnitEngineNotFoundException.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:NUnit.Engine.NUnitEngineNotFoundException"/> class.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.NUnitEngineNotFoundException.#ctor(System.Version)">
+            <summary>
+            Initializes a new instance of the <see cref="T:NUnit.Engine.NUnitEngineNotFoundException"/> class.
+            </summary>
+            <param name="minVersion">The minimum version.</param>
+        </member>
+        <member name="T:NUnit.Engine.ILogging">
+            <summary>
+            Interface to abstract getting loggers
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ILogging.GetLogger(System.String)">
+            <summary>
+            Gets the logger.
+            </summary>
+            <param name="name">The name of the logger to get.</param>
+            <returns></returns>
+        </member>
+        <member name="T:NUnit.Engine.IServiceLocator">
+            <summary>
+            IServiceLocator allows clients to locate any NUnit services
+            for which the interface is referenced. In normal use, this
+            linits it to those services using interfaces defined in the 
+            nunit.engine.api assembly.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IServiceLocator.GetService``1">
+            <summary>
+            Return a specified type of service
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IServiceLocator.GetService(System.Type)">
+            <summary>
+            Return a specified type of service
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.SettingsEventHandler">
+            <summary>
+            Event handler for settings changes
+            </summary>
+            <param name="sender">The sender.</param>
+            <param name="args">The <see cref="T:NUnit.Engine.SettingsEventArgs"/> instance containing the event data.</param>
+        </member>
+        <member name="T:NUnit.Engine.SettingsEventArgs">
+            <summary>
+            Event argument for settings changes
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.SettingsEventArgs.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:NUnit.Engine.SettingsEventArgs"/> class.
+            </summary>
+            <param name="settingName">Name of the setting that has changed.</param>
+        </member>
+        <member name="P:NUnit.Engine.SettingsEventArgs.SettingName">
+            <summary>
+            Gets the name of the setting that has changed
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.ISettings">
+            <summary>
+            The ISettings interface is used to access all user
+            settings and options.
+            </summary>
+        </member>
+        <member name="E:NUnit.Engine.ISettings.Changed">
+            <summary>
+            Occurs when the settings are changed.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ISettings.GetSetting(System.String)">
+            <summary>
+            Load a setting from the storage.
+            </summary>
+            <param name="settingName">Name of the setting to load</param>
+            <returns>Value of the setting or null</returns>
+        </member>
+        <member name="M:NUnit.Engine.ISettings.GetSetting``1(System.String,``0)">
+            <summary>
+            Load a setting from the storage or return a default value
+            </summary>
+            <param name="settingName">Name of the setting to load</param>
+            <param name="defaultValue">Value to return if the setting is missing</param>
+            <returns>Value of the setting or the default value</returns>
+        </member>
+        <member name="M:NUnit.Engine.ISettings.RemoveSetting(System.String)">
+            <summary>
+            Remove a setting from the storage
+            </summary>
+            <param name="settingName">Name of the setting to remove</param>
+        </member>
+        <member name="M:NUnit.Engine.ISettings.RemoveGroup(System.String)">
+            <summary>
+            Remove an entire group of settings from the storage
+            </summary>
+            <param name="groupName">Name of the group to remove</param>
+        </member>
+        <member name="M:NUnit.Engine.ISettings.SaveSetting(System.String,System.Object)">
+            <summary>
+            Save a setting in the storage
+            </summary>
+            <param name="settingName">Name of the setting to save</param>
+            <param name="settingValue">Value to be saved</param>
+        </member>
+        <member name="T:NUnit.Engine.ITestEngine">
+            <summary>
+            ITestEngine represents an instance of the test engine.
+            Clients wanting to discover, explore or run tests start
+            require an instance of the engine, which is generally 
+            acquired from the TestEngineActivator class.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.ITestEngine.Services">
+            <summary>
+            Gets the IServiceLocator interface, which gives access to
+            certain services provided by the engine.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.ITestEngine.WorkDirectory">
+            <summary>
+            Gets and sets the directory path used by the engine for saving files.
+            Some services may ignore changes to this path made after initialization.
+            The default value is the current directory.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.ITestEngine.InternalTraceLevel">
+            <summary>
+            Gets and sets the InternalTraceLevel used by the engine. Changing this
+            setting after initialization will have no effect. The default value
+            is the value saved in the NUnit settings.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestEngine.Initialize">
+            <summary>
+            Initialize the engine. This includes initializing mono addins,
+            setting the trace level and creating the standard set of services 
+            used in the Engine.
+            
+            This interface is not normally called by user code. Programs linking 
+            only to the nunit.engine.api assembly are given a
+            pre-initialized instance of TestEngine. Programs 
+            that link directly to nunit.engine usually do so
+            in order to perform custom initialization.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestEngine.GetRunner(NUnit.Engine.TestPackage)">
+            <summary>
+            Returns a test runner instance for use by clients in discovering,
+            exploring and executing tests.
+            </summary>
+            <param name="package">The TestPackage for which the runner is intended.</param>
+            <returns>An ITestRunner.</returns>
+        </member>
+        <member name="T:NUnit.Engine.ITestEventListener">
+            <summary>
+            The ITestListener interface is used to receive notices of significant
+            events while a test is running. It's single method accepts an Xml string, 
+            which may represent any event generated by the test framework, the driver
+            or any of the runners internal to the engine. Use of Xml means that
+            any driver and framework may add additional events and the engine will
+            simply pass them on through this interface.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestEventListener.OnTestEvent(System.String)">
+            <summary>
+            Handle a progress report or other event.
+            </summary>
+            <param name="report">An XML progress report.</param>
+        </member>
+        <member name="T:NUnit.Engine.ITestRunner">
+            <summary>
+            Interface implemented by all test runners.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.ITestRunner.IsTestRunning">
+            <summary>
+            Get a flag indicating whether a test is running
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.Load">
+            <summary>
+            Load a TestPackage for possible execution
+            </summary>
+            <returns>An XmlNode representing the loaded package.</returns>
+            <remarks>
+            This method is normally optional, since Explore and Run call
+            it automatically when necessary. The method is kept in order
+            to make it easier to convert older programs that use it.
+            </remarks>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.Unload">
+            <summary>
+            Unload any loaded TestPackage. If none is loaded,
+            the call is ignored.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.Reload">
+            <summary>
+            Reload the current TestPackage
+            </summary>
+            <returns>An XmlNode representing the loaded package.</returns>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.CountTestCases(NUnit.Engine.TestFilter)">
+            <summary>
+            Count the test cases that would be run under
+            the specified filter.
+            </summary>
+            <param name="filter">A TestFilter</param>
+            <returns>The count of test cases</returns>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.Run(NUnit.Engine.ITestEventListener,NUnit.Engine.TestFilter)">
+            <summary>
+            Run the tests in the loaded TestPackage and return a test result. The tests
+            are run synchronously and the listener interface is notified as it progresses.
+            </summary>
+            <param name="listener">The listener that is notified as the run progresses</param>
+            <param name="filter">A TestFilter used to select tests</param>
+            <returns>An XmlNode giving the result of the test execution</returns>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.RunAsync(NUnit.Engine.ITestEventListener,NUnit.Engine.TestFilter)">
+            <summary>
+            Start a run of the tests in the loaded TestPackage. The tests are run
+            asynchronously and the listener interface is notified as it progresses.
+            </summary>
+            <param name="listener">The listener that is notified as the run progresses</param>
+            <param name="filter">A TestFilter used to select tests</param>
+            <returns></returns>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.StopRun(System.Boolean)">
+            <summary>
+            Cancel the ongoing test run. If no  test is running, the call is ignored.
+            </summary>
+            <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
+        </member>
+        <member name="M:NUnit.Engine.ITestRunner.Explore(NUnit.Engine.TestFilter)">
+            <summary>
+            Explore a loaded TestPackage and return information about the tests found.
+            </summary>
+            <param name="filter">The TestFilter to be used in selecting tests to explore.</param>
+            <returns>An XmlNode representing the tests found.</returns>
+        </member>
+        <member name="T:NUnit.Engine.NUnitEngineException">
+            <summary>
+            NUnitEngineException is thrown when the engine has been
+            called with improper values or when a particular facility
+            is not available.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.NUnitEngineException.#ctor(System.String)">
+            <summary>
+            Construct with a message
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.NUnitEngineException.#ctor(System.String,System.Exception)">
+            <summary>
+            Construct with a message and inner exception
+            </summary>
+            <param name="message"></param>
+            <param name="innerException"></param>
+        </member>
+        <member name="M:NUnit.Engine.NUnitEngineException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+            <summary>
+            Serialization constructor
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.IRecentFiles">
+            <summary>
+            The IRecentFiles interface is used to isolate the app
+            from various implementations of recent files.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRecentFiles.MaxFiles">
+            <summary>
+            The max number of files saved
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IRecentFiles.Entries">
+            <summary>
+            Get a list of all the file entries
+            </summary>
+            <returns>The most recent file list</returns>
+        </member>
+        <member name="M:NUnit.Engine.IRecentFiles.SetMostRecent(System.String)">
+            <summary>
+            Set the most recent file name, reordering
+            the saved names as needed and removing the oldest
+            if the max number of files would be exceeded.
+            The current CLR version is used to create the entry.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IRecentFiles.Remove(System.String)">
+            <summary>
+            Remove a file from the list
+            </summary>
+            <param name="fileName">The name of the file to remove</param>
+        </member>
+        <member name="T:NUnit.Engine.TestEngineActivator">
+            <summary>
+            TestEngineActivator creates an instance of the test engine and returns an ITestEngine interface.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.TestEngineActivator.CreateInstance(System.Boolean)">
+            <summary>
+            Create an instance of the test engine.
+            </summary>
+            <remarks>If private copy is false, the search order is the NUnit install directory for the current user, then
+            the install directory for the local machine and finally the current AppDomain's ApplicationBase.</remarks>
+            <param name="privateCopy">if set to <c>true</c> loads the engine found in the application base directory, 
+            otherwise searches for the test engine with the highest version installed. Defaults to <c>true</c>.</param>
+            <exception cref="T:NUnit.Engine.NUnitEngineNotFoundException">Thrown when a test engine of the required minimum version is not found</exception>
+            <returns>An <see cref="T:NUnit.Engine.ITestEngine"/></returns>
+        </member>
+        <member name="M:NUnit.Engine.TestEngineActivator.CreateInstance(System.Version,System.Boolean)">
+            <summary>
+            Create an instance of the test engine with a minimum version.
+            </summary>
+            <remarks>If private copy is false, the search order is the NUnit install directory for the current user, then
+            the install directory for the local machine and finally the current AppDomain's ApplicationBase.</remarks>
+            <param name="minVersion">The minimum version of the engine to return inclusive.</param>
+            <param name="privateCopy">if set to <c>true</c> loads the engine found in the application base directory, 
+            otherwise searches for the test engine with the highest version installed. Defaults to <c>true</c>.</param>
+            <exception cref="T:NUnit.Engine.NUnitEngineNotFoundException">Thrown when a test engine of the given minimum version is not found</exception>
+            <returns>An <see cref="T:NUnit.Engine.ITestEngine"/></returns>
+        </member>
+        <member name="T:NUnit.Engine.TestFilter">
+            <summary>
+            Abstract base for all test filters. A filter is represented
+            by an XmlNode with &lt;filter&gt; as it's topmost element.
+            In the console runner, filters serve only to carry this
+            XML representation, as all filtering is done by the engine.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.TestFilter.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:NUnit.Engine.TestFilter"/> class.
+            </summary>
+            <param name="xmlText">The XML text that specifies the filter.</param>
+        </member>
+        <member name="F:NUnit.Engine.TestFilter.Empty">
+            <summary>
+            The empty filter - one that always passes.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.TestFilter.Text">
+            <summary>
+            Gets the XML representation of this filter as a string.
+            </summary>
+        </member>
+        <member name="T:NUnit.Engine.TestPackage">
+            <summary>
+            TestPackage holds information about a set of test files to
+            be loaded by a TestRunner. Each TestPackage represents
+            tests for one or more test files. TestPackages may be named 
+            or anonymous, depending on how they are constructed.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.TestPackage.#ctor(System.String)">
+            <summary>
+            Construct a named TestPackage, specifying a file path for
+            the assembly or project to be used.
+            </summary>
+            <param name="filePath">The file path.</param>
+        </member>
+        <member name="M:NUnit.Engine.TestPackage.#ctor(System.Collections.Generic.IList{System.String})">
+            <summary>
+            Construct an anonymous TestPackage that wraps test files.
+            </summary>
+            <param name="testFiles"></param>
+        </member>
+        <member name="P:NUnit.Engine.TestPackage.ID">
+            <summary>
+            Every test package gets a unique ID used to prefix test IDs within that package.
+            </summary>
+            <remarks>
+            The generated ID is only unique for packages created within the same AppDomain.
+            For that reason, NUnit pre-creates all test packages that will be needed.
+            </remarks>
+        </member>
+        <member name="P:NUnit.Engine.TestPackage.Name">
+            <summary>
+            Gets the name of the package
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.TestPackage.FullName">
+            <summary>
+            Gets the path to the file containing tests. It may be
+            an assembly or a recognized project type.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.TestPackage.SubPackages">
+            <summary>
+            Gets the list of SubPackages contained in this package
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.TestPackage.Settings">
+            <summary>
+            Gets the settings dictionary for this package.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.TestPackage.AddSubPackage(NUnit.Engine.TestPackage)">
+            <summary>
+            Add a subproject to the package.
+            </summary>
+            <param name="subPackage">The subpackage to be added</param>
+        </member>
+        <member name="M:NUnit.Engine.TestPackage.AddSetting(System.String,System.Object)">
+            <summary>
+            Add a setting to a package and all of its subpackages.
+            </summary>
+            <param name="name">The name of the setting</param>
+            <param name="value">The value of the setting</param>
+            <remarks>
+            Once a package is created, subpackages may have been created
+            as well. If you add a setting directly to the Settings dictionary
+            of the package, the subpackages are not updated. This method is
+            used when the settings are intended to be reflected to all the
+            subpackages under the package.
+            </remarks>
+        </member>
+        <member name="M:NUnit.Engine.TestPackage.GetSetting``1(System.String,``0)">
+            <summary>
+            Return the value of a setting or a default.
+            </summary>
+            <param name="name">The name of the setting</param>
+            <param name="defaultSetting">The default value</param>
+            <returns></returns>
+        </member>
+        <member name="T:NUnit.Engine.ITestRun">
+            <summary>
+            The ITestRun class represents an ongoing test run.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.ITestRun.Result">
+            <summary>
+            Get the result of the test.
+            </summary>
+            <returns>An XmlNode representing the test run result</returns>
+        </member>
+        <member name="M:NUnit.Engine.ITestRun.Wait(System.Int32)">
+            <summary>
+            Blocks the current thread until the current test run completes
+            or the timeout is reached
+            </summary>
+            <param name="timeout">A <see cref="T:System.Int32"/> that represents the number of milliseconds to wait or -1 milliseconds to wait indefinitely. </param>
+            <returns>True if the run completed</returns>
+        </member>
+        <member name="T:NUnit.Engine.IExtensionService">
+            <summary>
+            The IExtensionService interface allows a runner to manage extensions.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IExtensionService.ExtensionPoints">
+            <summary>
+            Gets an enumeration of all ExtensionPoints in the engine.
+            </summary>
+        </member>
+        <member name="P:NUnit.Engine.IExtensionService.Extensions">
+            <summary>
+            Gets an enumeration of all installed Extensions.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IExtensionService.GetExtensionPoint(System.String)">
+            <summary>
+            Get an ExtensionPoint based on it's unique identifying path.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IExtensionService.GetExtensionNodes(System.String)">
+            <summary>
+            Get an enumeration of ExtensionNodes based on their identifying path.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.IExtensionService.EnableExtension(System.String,System.Boolean)">
+            <summary>
+            Enable or disable an extension
+            </summary>
+            <param name="typeName"></param>
+            <param name="enabled"></param>
+        </member>
+        <member name="T:NUnit.Engine.TestSelectionParserException">
+            <summary>
+            TestSelectionParserException is thrown when an error 
+            is found while parsing the selection expression.
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.TestSelectionParserException.#ctor(System.String)">
+            <summary>
+            Construct with a message
+            </summary>
+        </member>
+        <member name="M:NUnit.Engine.TestSelectionParserException.#ctor(System.String,System.Exception)">
+            <summary>
+            Construct with a message and inner exception
+            </summary>
+            <param name="message"></param>
+            <param name="innerException"></param>
+        </member>
+        <member name="M:NUnit.Engine.TestSelectionParserException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+            <summary>
+            Serialization constructor
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit.nuget.addins
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit.nuget.addins
@@ -1,0 +1,2 @@
+../../NUnit.Extension.*/**/tools/     # nuget v2 layout
+../../../NUnit.Extension.*/**/tools/  # nuget v3 layout

--- a/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe.config
+++ b/.nuget/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+   The console runner runs under .NET 2.0 or higher. 
+   The setting useLegacyV2RuntimeActivationPolicy only applies 
+   under .NET 4.0 and permits use of mixed mode assemblies, 
+   which would otherwise not load correctly.
+  -->
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0.30319" />
+    <supportedRuntime version="v2.0.50727" />
+  </startup>
+
+  <runtime>
+    
+    <!-- Ensure that test exceptions don't crash NUnit -->
+    <legacyUnhandledExceptionPolicy enabled="1" />
+
+    <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
+    <loadFromRemoteSources enabled="true" />
+    
+  </runtime>
+  
+</configuration>

--- a/.nuget/NUnit.Extension.NUnitV2Driver.3.6.0/LICENSE.txt
+++ b/.nuget/NUnit.Extension.NUnitV2Driver.3.6.0/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2016 Charlie Poole
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/.nuget/NUnit.Extension.NUnitV2Driver.3.6.0/tools/nunit.v2.driver.addins
+++ b/.nuget/NUnit.Extension.NUnitV2Driver.3.6.0/tools/nunit.v2.driver.addins
@@ -1,0 +1,1 @@
+nunit.v2.driver.dll

--- a/.nuget/NUnit.Extension.TeamCityEventListener.1.0.2/LICENSE.txt
+++ b/.nuget/NUnit.Extension.TeamCityEventListener.1.0.2/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2016 Charlie Poole
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/SharpRepository.CacheRepository/CacheRepositoryBase.cs
+++ b/SharpRepository.CacheRepository/CacheRepositoryBase.cs
@@ -93,7 +93,7 @@ namespace SharpRepository.CacheRepository
         {
             TKey id;
 
-            if (GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
+            if (GetPrimaryKey(entity, out id) && GenerateKeyOnAdd && Equals(id, default(TKey)))
             {
                 id = GeneratePrimaryKey();
                 SetPrimaryKey(entity, id);

--- a/SharpRepository.CouchDbRepository/CouchDbRepositoryBase.cs
+++ b/SharpRepository.CouchDbRepository/CouchDbRepositoryBase.cs
@@ -268,7 +268,7 @@ namespace SharpRepository.CouchDbRepository
         protected override void AddItem(T entity)
         {
             string id;
-            if (GetPrimaryKey(entity, out id) && Equals(id, default(string)))
+            if (GetPrimaryKey(entity, out id) && GenerateKeyOnAdd && Equals(id, default(string)))
             {
                 id = GeneratePrimaryKey();
                 SetPrimaryKey(entity, id);

--- a/SharpRepository.Db4oRepository/Db4ORepositoryBase.cs
+++ b/SharpRepository.Db4oRepository/Db4ORepositoryBase.cs
@@ -43,7 +43,7 @@ namespace SharpRepository.Db4oRepository
         {
             TKey id;
 
-            if (GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
+            if (GenerateKeyOnAdd && GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
             {
                 id = GeneratePrimaryKey();
                 SetPrimaryKey(entity, id);

--- a/SharpRepository.EfRepository/EfRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfRepositoryBase.cs
@@ -14,7 +14,6 @@ namespace SharpRepository.EfRepository
     {
         protected IDbSet<T> DbSet { get; private set; }
         protected DbContext Context { get; private set; }
-        public bool GenerateKeyOnAdd { get; set; }
 
         internal EfRepositoryBase(DbContext dbContext, ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy)
         {
@@ -34,7 +33,7 @@ namespace SharpRepository.EfRepository
             if (typeof(TKey) == typeof(Guid) || typeof(TKey) == typeof(string))
             {
                 TKey id;
-                if (GetPrimaryKey(entity, out id) && GenerateKeyOnAdd && Equals(id, default(TKey)))
+                if (GenerateKeyOnAdd && GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
                 {
                     id = GeneratePrimaryKey();
                     SetPrimaryKey(entity, id);

--- a/SharpRepository.EfRepository/EfRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfRepositoryBase.cs
@@ -14,11 +14,12 @@ namespace SharpRepository.EfRepository
     {
         protected IDbSet<T> DbSet { get; private set; }
         protected DbContext Context { get; private set; }
+        public bool GenerateKeyOnAdd { get; set; }
 
         internal EfRepositoryBase(DbContext dbContext, ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy)
         {
             if (dbContext == null) throw new ArgumentNullException("dbContext");
-
+            GenerateKeyOnAdd = true;
             Initialize(dbContext);
         }
 
@@ -32,7 +33,8 @@ namespace SharpRepository.EfRepository
         {
             if (typeof(TKey) == typeof(Guid) || typeof(TKey) == typeof(string))
             {
-                if (GetPrimaryKey(entity, out TKey id) && Equals(id, default(TKey)))
+                TKey id;
+                if (GetPrimaryKey(entity, out id) && GenerateKeyOnAdd && Equals(id, default(TKey)))
                 {
                     id = GeneratePrimaryKey();
                     SetPrimaryKey(entity, id);

--- a/SharpRepository.EfRepository/EfRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfRepositoryBase.cs
@@ -18,7 +18,6 @@ namespace SharpRepository.EfRepository
         internal EfRepositoryBase(DbContext dbContext, ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy)
         {
             if (dbContext == null) throw new ArgumentNullException("dbContext");
-            GenerateKeyOnAdd = true;
             Initialize(dbContext);
         }
 

--- a/SharpRepository.InMemoryRepository/InMemoryRepositoryBase.cs
+++ b/SharpRepository.InMemoryRepository/InMemoryRepositoryBase.cs
@@ -11,9 +11,11 @@ namespace SharpRepository.InMemoryRepository
     public abstract class InMemoryRepositoryBase<T, TKey> : LinqRepositoryBase<T, TKey> where T : class, new()
     {
         private readonly ConcurrentDictionary<TKey, T> _items = new ConcurrentDictionary<TKey, T>();
+        public bool GenerateKeyOnAdd { get; set; }
 
-        internal InMemoryRepositoryBase(ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy) 
-        {   
+        internal InMemoryRepositoryBase(ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy)
+        {
+            GenerateKeyOnAdd = true;
         }
 
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)
@@ -59,7 +61,7 @@ namespace SharpRepository.InMemoryRepository
         {
             TKey id;
 
-            if (GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
+            if (GetPrimaryKey(entity, out id) && GenerateKeyOnAdd && Equals(id, default(TKey)))
             {
                 id = GeneratePrimaryKey();
                 SetPrimaryKey(entity, id);

--- a/SharpRepository.InMemoryRepository/InMemoryRepositoryBase.cs
+++ b/SharpRepository.InMemoryRepository/InMemoryRepositoryBase.cs
@@ -14,7 +14,7 @@ namespace SharpRepository.InMemoryRepository
 
         internal InMemoryRepositoryBase(ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy)
         {
-            GenerateKeyOnAdd = true;
+            
         }
 
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)

--- a/SharpRepository.InMemoryRepository/InMemoryRepositoryBase.cs
+++ b/SharpRepository.InMemoryRepository/InMemoryRepositoryBase.cs
@@ -11,7 +11,6 @@ namespace SharpRepository.InMemoryRepository
     public abstract class InMemoryRepositoryBase<T, TKey> : LinqRepositoryBase<T, TKey> where T : class, new()
     {
         private readonly ConcurrentDictionary<TKey, T> _items = new ConcurrentDictionary<TKey, T>();
-        public bool GenerateKeyOnAdd { get; set; }
 
         internal InMemoryRepositoryBase(ICachingStrategy<T, TKey> cachingStrategy = null) : base(cachingStrategy)
         {

--- a/SharpRepository.MongoDbRepository/MongoDbRepositoryBase.cs
+++ b/SharpRepository.MongoDbRepository/MongoDbRepositoryBase.cs
@@ -394,6 +394,20 @@ namespace SharpRepository.MongoDbRepository
                 ?? base.GetPrimaryKeyPropertyInfo();
         }
 
+        public override bool GenerateKeyOnAdd
+        {
+            get { return base.GenerateKeyOnAdd; }
+            set
+            {
+                if (value == false)
+                {
+                    throw new NotSupportedException("Mongo DB driver always generates key values. SharpRepository can't avoid it.");
+                }
+
+                base.GenerateKeyOnAdd = value;
+            }
+        }
+
         public override void Dispose()
         {
         }

--- a/SharpRepository.RavenDbRepository/RavenDbRepositoryBase.cs
+++ b/SharpRepository.RavenDbRepository/RavenDbRepositoryBase.cs
@@ -344,6 +344,20 @@ namespace SharpRepository.RavenDbRepository
                 DocumentStore.Dispose();
         }
 
+        public override bool GenerateKeyOnAdd
+        {
+            get { return base.GenerateKeyOnAdd; }
+            set
+            {
+                if (value == false)
+                {
+                    throw new NotSupportedException("Raven DB driver always generates key values. SharpRepository can't avoid it.");
+                }
+
+                base.GenerateKeyOnAdd = value;
+            }
+        }
+
         private TKey GeneratePrimaryKey()
         {
             if (typeof(TKey) == typeof(Guid))

--- a/SharpRepository.RavenDbRepository/RavenDbRepositoryBase.cs
+++ b/SharpRepository.RavenDbRepository/RavenDbRepositoryBase.cs
@@ -311,7 +311,7 @@ namespace SharpRepository.RavenDbRepository
         {
             TKey id;
             
-            if (GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
+            if (GenerateKeyOnAdd && GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
             {
                 id = GeneratePrimaryKey();
                 SetPrimaryKey(entity, id);

--- a/SharpRepository.Repository/ConfigurationBasedRepository.cs
+++ b/SharpRepository.Repository/ConfigurationBasedRepository.cs
@@ -406,6 +406,12 @@ namespace SharpRepository.Repository
             get { return Repository.TraceInfo; }
         }
 
+        public bool GenerateKeyOnAdd
+        {
+            get { return Repository.GenerateKeyOnAdd; }
+            set { Repository.GenerateKeyOnAdd = value; }
+        }
+
         public TKey GetPrimaryKey(T entity)
         {
             return Repository.GetPrimaryKey(entity);

--- a/SharpRepository.Repository/ICrudRepository.cs
+++ b/SharpRepository.Repository/ICrudRepository.cs
@@ -153,5 +153,10 @@ namespace SharpRepository.Repository
         string TraceInfo { get; }
 
         TKey GetPrimaryKey(T entity);
+
+        /// <summary>
+        /// Gets or sets whether the repository should generate primary key value automatically when Add is called.
+        /// </summary>
+        bool GenerateKeyOnAdd { get; set; }
     }
 }

--- a/SharpRepository.Repository/RepositoryBase.cs
+++ b/SharpRepository.Repository/RepositoryBase.cs
@@ -23,6 +23,7 @@ namespace SharpRepository.Repository
                 throw new InvalidOperationException("The repository type and the primary key type can not be the same.");
             }
 
+            GenerateKeyOnAdd = true;
             Conventions = new RepositoryConventions();
             CachingStrategy = cachingStrategy ?? new NoCachingStrategy<T, TKey>(); // sets QueryManager as well
             // the CachePrefix is set to the default convention in the CachingStrategyBase class, the user to override when passing in an already created CachingStrategy class
@@ -1575,6 +1576,8 @@ namespace SharpRepository.Repository
             SetTraceInfo(caller, query.ToString(), append);
         }
         public string TraceInfo { get; protected set; }
+
+        public bool GenerateKeyOnAdd { get; set; }
 
         public TKey GetPrimaryKey(T entity)
         {

--- a/SharpRepository.Repository/RepositoryBase.cs
+++ b/SharpRepository.Repository/RepositoryBase.cs
@@ -1577,7 +1577,7 @@ namespace SharpRepository.Repository
         }
         public string TraceInfo { get; protected set; }
 
-        public bool GenerateKeyOnAdd { get; set; }
+        public virtual bool GenerateKeyOnAdd { get; set; }
 
         public TKey GetPrimaryKey(T entity)
         {

--- a/SharpRepository.Tests.Integration/RepositoryAddTests.cs
+++ b/SharpRepository.Tests.Integration/RepositoryAddTests.cs
@@ -20,7 +20,7 @@ namespace SharpRepository.Tests.Integration
             contact.ContactId.ShouldNotBeEmpty();
         }
 
-        [ExecuteForAllRepositoriesExcept(RepositoryType.RavenDb, Reason = "Depends on driver to generate a value")]
+        [ExecuteForAllRepositoriesExcept(RepositoryType.RavenDb, RepositoryType.MongoDb, Reason = "Depends on driver to generate a value")]
         public void Add_Should_Save_But_Not_Assign_New_Id_When_GenerateKeyOnAdd_Is_False(IRepository<Contact, string> repository)
         {
             var contact = new Contact { ContactId = string.Empty, Name = "Test User" };

--- a/SharpRepository.Tests.Integration/RepositoryAddTests.cs
+++ b/SharpRepository.Tests.Integration/RepositoryAddTests.cs
@@ -19,7 +19,16 @@ namespace SharpRepository.Tests.Integration
             repository.Add(contact);
             contact.ContactId.ShouldNotBeEmpty();
         }
-        
+
+        [ExecuteForAllRepositoriesExcept(RepositoryType.RavenDb, Reason = "Depends on driver to generate a value")]
+        public void Add_Should_Save_But_Not_Assign_New_Id_When_GenerateKeyOnAdd_Is_False(IRepository<Contact, string> repository)
+        {
+            var contact = new Contact { ContactId = string.Empty, Name = "Test User" };
+            repository.GenerateKeyOnAdd = false;
+            repository.Add(contact);
+            contact.ContactId.ShouldBeEmpty();
+        }
+
         [ExecuteForAllRepositories]
         public void Add_Should_Result_In_Proper_Total_Items(IRepository<Contact, string> repository)
         {

--- a/SharpRepository.Tests/App.config
+++ b/SharpRepository.Tests/App.config
@@ -53,7 +53,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
 			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>

--- a/SharpRepository.Tests/Conventions/DefaultConventionTests.cs
+++ b/SharpRepository.Tests/Conventions/DefaultConventionTests.cs
@@ -3,6 +3,7 @@ using SharpRepository.Repository;
 using SharpRepository.Repository.Caching;
 using SharpRepository.Tests.TestObjects;
 using Should;
+using System;
 
 namespace SharpRepository.Tests.Conventions
 {
@@ -58,6 +59,25 @@ namespace SharpRepository.Tests.Conventions
 
             var repos = new InMemoryRepository.InMemoryRepository<Contact>(new StandardCachingStrategy<Contact, int>());
             repos.CachingStrategy.FullCachePrefix.ShouldStartWith(newPrefix);
+        }
+
+        [Test]
+        public void RavenDb_Throws_NotSupportedException_When_GenerateKeyOnAdd_Is_Set_False()
+        {
+            var ravenDbRepo = new RavenDbRepository.RavenDbRepository<Contact>();
+            Exception actualException = null;
+
+            try
+            {
+                ravenDbRepo.GenerateKeyOnAdd = false;
+            }
+            catch(Exception ex)
+            {
+                actualException = ex;
+            }
+
+            actualException.ShouldNotBeNull();
+            actualException.ShouldBeType<NotSupportedException>();
         }
 
         internal class TestConventionObject

--- a/SharpRepository.Tests/SharpRepository.Tests.csproj
+++ b/SharpRepository.Tests/SharpRepository.Tests.csproj
@@ -150,6 +150,10 @@
       <Project>{dc40febe-2e39-4cb8-ae11-dfe9f6865bd2}</Project>
       <Name>SharpRepository.MongoDbRepository</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SharpRepository.RavenDbRepository\SharpRepository.RavenDbRepository.csproj">
+      <Project>{0d7303b9-3a89-4932-b0f0-73b0c1c0faed}</Project>
+      <Name>SharpRepository.RavenDbRepository</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SharpRepository.Repository\SharpRepository.Repository.csproj">
       <Project>{710DEE79-25CE-4F68-B8B1-D08A135AD154}</Project>
       <Name>SharpRepository.Repository</Name>

--- a/SharpRepository.Tests/project.json
+++ b/SharpRepository.Tests/project.json
@@ -27,6 +27,7 @@
     "servicestack.redis": "3.9.29",
     "servicestack.text": "3.9.28",
     "should": "1.1.20",
+    "System.Runtime": "4.0.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
     "System.Spatial": "5.6.4",
     "windowsazure.storage": "7.2.1"

--- a/SharpRepository.XmlRepository/XmlRepositoryBase.cs
+++ b/SharpRepository.XmlRepository/XmlRepositoryBase.cs
@@ -97,7 +97,7 @@ namespace SharpRepository.XmlRepository
         {
             TKey id;
 
-            if (GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
+            if (GenerateKeyOnAdd && GetPrimaryKey(entity, out id) && Equals(id, default(TKey)))
             {
                 id = GeneratePrimaryKey();
                 SetPrimaryKey(entity, id);


### PR DESCRIPTION
InMemoryRepository and EfRepository got a new property GenerateKeyOnAdd, which defaults to ```true```.

When value is ```false``` the repository won't automatically generate a key value on ```AddItem```, even if the current value is equal to ```default(TKey)```.

Makes it possible to add entities like ```MessageStatus { StatusId = 0, Description = "NotSent" }```.

Fixes issue #173 