### PR TITLE
Replace Rhino Mock

### DIFF
--- a/SharpRepository.Tests/App.config
+++ b/SharpRepository.Tests/App.config
@@ -7,7 +7,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
-  </configSections>
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <connectionStrings>
     <add name="EfConnectionString" connectionString="Data Source=test.mdf" />
   </connectionStrings>
@@ -41,7 +41,7 @@
     </servers>
   </memcached>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />

--- a/SharpRepository.Tests/SharpRepository.Tests.csproj
+++ b/SharpRepository.Tests/SharpRepository.Tests.csproj
@@ -34,6 +34,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
@@ -76,6 +80,10 @@
       <HintPath>..\packages\mongocsharpdriver.1.11.0\lib\net35\MongoDB.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Moq, Version=4.7.1.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.7.1\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -86,9 +94,6 @@
     <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Rhino.Mocks">
-      <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Common">
       <HintPath>..\packages\ServiceStack.Common.3.9.28\lib\net35\ServiceStack.Common.dll</HintPath>

--- a/SharpRepository.Tests/SharpRepository.Tests.csproj
+++ b/SharpRepository.Tests/SharpRepository.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharpRepository.Tests</RootNamespace>
     <AssemblyName>SharpRepository.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -35,11 +35,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.0.1\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.0.1\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Enyim.Caching, Version=2.13.0.0, Culture=neutral, PublicKeyToken=cec98615db04012e, processorArchitecture=MSIL">
       <HintPath>..\packages\EnyimMemcached.2.13\lib\net35\Enyim.Caching.dll</HintPath>
@@ -182,7 +183,9 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharpRepository.AzureBlobRepository\SharpRepository.AzureBlobRepository.csproj">

--- a/SharpRepository.Tests/TestBase.cs
+++ b/SharpRepository.Tests/TestBase.cs
@@ -1,4 +1,4 @@
-using Rhino.Mocks;
+using Moq;
 
 namespace SharpRepository.Tests
 {
@@ -17,7 +17,8 @@ namespace SharpRepository.Tests
         /// <returns>T</returns>
         protected static T M<T>(params object[] argumentsForConstructor) where T : class
         {
-            return MockRepository.GenerateMock<T>(argumentsForConstructor);
+            var mock = new MockRepository(MockBehavior.Default).Create<T>(argumentsForConstructor);
+            return mock.Object;
         }
 
         /// <summary>
@@ -28,7 +29,7 @@ namespace SharpRepository.Tests
         /// <returns>T</returns>
         protected static T Pm<T>(params object[] argumentsForConstructor) where T : class
         {
-            return MockRepository.GeneratePartialMock<T>(argumentsForConstructor);
+            return M<T>(argumentsForConstructor);
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace SharpRepository.Tests
         /// <returns>T</returns>
         protected static T S<T>(params object[] argumentsForConstructor) where T : class
         {
-            return MockRepository.GenerateStub<T>(argumentsForConstructor);
+            return M<T>(argumentsForConstructor);
         }
     }
 }

--- a/SharpRepository.Tests/packages.config
+++ b/SharpRepository.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="EnyimMemcached" version="2.13" targetFramework="net40" />
   <package id="log4net" version="2.0.0" targetFramework="net40" />
@@ -8,10 +9,10 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net40" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net40" />
   <package id="mongocsharpdriver" version="1.11.0" targetFramework="net40" />
+  <package id="Moq" version="4.7.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" requireReinstallation="true" />
   <package id="NLog" version="2.0.1.2" targetFramework="net40" requireReinstallation="true" />
   <package id="NUnit" version="3.5.0" targetFramework="net40" requireReinstallation="true" />
-  <package id="RhinoMocks" version="3.6.1" requireReinstallation="true" />
   <package id="ServiceStack.Common" version="3.9.28" targetFramework="net40" />
   <package id="ServiceStack.Redis" version="3.9.29" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.9.28" targetFramework="net40" />

--- a/SharpRepository.Tests/packages.config
+++ b/SharpRepository.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.1" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="EnyimMemcached" version="2.13" targetFramework="net40" />
   <package id="log4net" version="2.0.0" targetFramework="net40" />
   <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="net40" />
@@ -8,10 +8,10 @@
   <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net40" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net40" />
   <package id="mongocsharpdriver" version="1.11.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
-  <package id="NLog" version="2.0.1.2" targetFramework="net40" />
-  <package id="NUnit" version="3.5.0" targetFramework="net40" />
-  <package id="RhinoMocks" version="3.6.1" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" requireReinstallation="true" />
+  <package id="NLog" version="2.0.1.2" targetFramework="net40" requireReinstallation="true" />
+  <package id="NUnit" version="3.5.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="RhinoMocks" version="3.6.1" requireReinstallation="true" />
   <package id="ServiceStack.Common" version="3.9.28" targetFramework="net40" />
   <package id="ServiceStack.Redis" version="3.9.29" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.9.28" targetFramework="net40" />


### PR DESCRIPTION
One of the dependencies of the unit test project doesn't seem to be moving to .NET Core.

Moq supports .NET Standard 1.3 and up, and it doesn't seem to break anything to replace Rhino Mock with Moq.

Part of the work to solve #136.

Since this task can be done independently of all other work needed to support .NET Core, I do it in a separate PR.