### PR TITLE
Fix bug 207: Revert change that used compiled query for GetAll

### DIFF
--- a/SharpRepository.Repository/CompoundKeyRepositoryBase.cs
+++ b/SharpRepository.Repository/CompoundKeyRepositoryBase.cs
@@ -136,10 +136,9 @@ namespace SharpRepository.Repository
         public IEnumerable<TResult> GetAll<TResult>(Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions, IFetchStrategy<T> fetchStrategy)
         {
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteGetAll(
-                () => GetAllQuery(queryOptions, fetchStrategy).Select(selectFunc).ToList(),
+                () => GetAllQuery(queryOptions, fetchStrategy).Select(selector).ToList(),
                 selector,
                 queryOptions
                 );
@@ -174,7 +173,6 @@ namespace SharpRepository.Repository
         public TResult Get<TResult>(Expression<Func<T, TResult>> selector, params object[] keys)
         {
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteGet(
                 () =>
@@ -184,7 +182,7 @@ namespace SharpRepository.Repository
                         return default(TResult);
 
                     var results = new[] { result };
-                    return results.AsEnumerable().Select(selectFunc).First();
+                    return results.AsQueryable().Select(selector).First();
                 },
                 selector,
                 keys
@@ -230,10 +228,9 @@ namespace SharpRepository.Repository
         public IEnumerable<TResult> FindAll<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions = null)
         {
             if (criteria == null) throw new ArgumentNullException("criteria");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteFindAll(
-                () => FindAllQuery(criteria, queryOptions).Select(selectFunc).ToList(),
+                () => FindAllQuery(criteria, queryOptions).Select(selector).ToList(),
                 criteria,
                 selector,
                 queryOptions
@@ -275,7 +272,6 @@ namespace SharpRepository.Repository
         {
             if (criteria == null) throw new ArgumentNullException("criteria");
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteFind(
                 () =>
@@ -285,7 +281,7 @@ namespace SharpRepository.Repository
                         return default(TResult);
 
                     var results = new[] { result };
-                    return results.AsEnumerable().Select(selectFunc).First();
+                    return results.AsQueryable().Select(selector).First();
                 },
                 criteria,
                 selector,
@@ -719,10 +715,9 @@ namespace SharpRepository.Repository
         public IEnumerable<TResult> GetAll<TResult>(Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions, IFetchStrategy<T> fetchStrategy)
         {
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteGetAll(
-                () => GetAllQuery(queryOptions, fetchStrategy).Select(selectFunc).ToList(),
+                () => GetAllQuery(queryOptions, fetchStrategy).Select(selector).ToList(),
                 selector,
                 queryOptions
                 );
@@ -758,7 +753,6 @@ namespace SharpRepository.Repository
         public TResult Get<TResult>(TKey key, TKey2 key2, Expression<Func<T, TResult>> selector)
         {
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteGet(
                 () =>
@@ -768,7 +762,7 @@ namespace SharpRepository.Repository
                         return default(TResult);
 
                     var results = new[] { result };
-                    return results.AsEnumerable().Select(selectFunc).First();
+                    return results.AsQueryable().Select(selector).First();
                 },
                 selector,
                 key,
@@ -830,10 +824,9 @@ namespace SharpRepository.Repository
         public IEnumerable<TResult> FindAll<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions = null)
         {
             if (criteria == null) throw new ArgumentNullException("criteria");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteFindAll(
-                () => FindAllQuery(criteria, queryOptions).Select(selectFunc).ToList(),
+                () => FindAllQuery(criteria, queryOptions).Select(selector).ToList(),
                 criteria,
                 selector,
                 queryOptions
@@ -875,7 +868,6 @@ namespace SharpRepository.Repository
         {
             if (criteria == null) throw new ArgumentNullException("criteria");
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteFind(
                 () =>
@@ -885,7 +877,7 @@ namespace SharpRepository.Repository
                             return default(TResult);
 
                         var results = new[] { result };
-                        return results.AsEnumerable().Select(selectFunc).First();
+                        return results.AsQueryable().Select(selector).First();
                     },
                 criteria,
                 selector,
@@ -1317,10 +1309,9 @@ namespace SharpRepository.Repository
         public IEnumerable<TResult> GetAll<TResult>(Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions, IFetchStrategy<T> fetchStrategy)
         {
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteGetAll(
-                () => GetAllQuery(queryOptions, fetchStrategy).Select(selectFunc).ToList(),
+                () => GetAllQuery(queryOptions, fetchStrategy).Select(selector).ToList(),
                 selector,
                 queryOptions
                 );
@@ -1357,7 +1348,6 @@ namespace SharpRepository.Repository
         public TResult Get<TResult>(TKey key, TKey2 key2, TKey3 key3, Expression<Func<T, TResult>> selector)
         {
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteGet(
                 () =>
@@ -1367,7 +1357,7 @@ namespace SharpRepository.Repository
                         return default(TResult);
 
                     var results = new[] { result };
-                    return results.AsEnumerable().Select(selectFunc).First();
+                    return results.AsQueryable().Select(selector).First();
                 },
                 selector,
                 key,
@@ -1430,10 +1420,9 @@ namespace SharpRepository.Repository
         public IEnumerable<TResult> FindAll<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions = null)
         {
             if (criteria == null) throw new ArgumentNullException("criteria");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteFindAll(
-                () => FindAllQuery(criteria, queryOptions).Select(selectFunc).ToList(),
+                () => FindAllQuery(criteria, queryOptions).Select(selector).ToList(),
                 criteria,
                 selector,
                 queryOptions
@@ -1475,7 +1464,6 @@ namespace SharpRepository.Repository
         {
             if (criteria == null) throw new ArgumentNullException("criteria");
             if (selector == null) throw new ArgumentNullException("selector");
-            var selectFunc = selector.Compile();
 
             return _queryManager.ExecuteFind(
                 () =>
@@ -1485,7 +1473,7 @@ namespace SharpRepository.Repository
                             return default(TResult);
 
                         var results = new[] { result };
-                        return results.AsEnumerable().Select(selectFunc).First();
+                        return results.AsQueryable().Select(selector).First();
                     },
                 criteria,
                 selector,

--- a/SharpRepository.Repository/RepositoryBase.cs
+++ b/SharpRepository.Repository/RepositoryBase.cs
@@ -267,12 +267,11 @@ namespace SharpRepository.Repository
 
                 // if the aspect altered the specificaiton then we need to run a FindAll with that specification
                 IEnumerable<TResult> results;
-                var selectFunc = context.Selector.Compile();
 
                 if (context.Specification == null)
                 {
                     results = QueryManager.ExecuteGetAll(
-                        () => GetAllQuery(context.QueryOptions, fetchStrategy).Select(selectFunc).ToList(),
+                        () => GetAllQuery(context.QueryOptions, fetchStrategy).Select(context.Selector).ToList(),
                         context.Selector,
                         context.QueryOptions
                         );
@@ -398,10 +397,9 @@ namespace SharpRepository.Repository
                     );
 
                 // return the entity with the selector applied to it
-                var selectFunc = selector.Compile();
                 var selectedResult = result == null
                     ? default(TResult)
-                    : new[] { result }.AsEnumerable().Select(selectFunc).First();
+                    : new[] { result }.AsQueryable().Select(selector).First();
 
                 context.Result = selectedResult;
                 RunAspect(attribute => attribute.OnGetExecuted(context));
@@ -538,9 +536,8 @@ namespace SharpRepository.Repository
                 if (!RunAspect(attribute => attribute.OnFindAllExecuting(context)))
                     return context.Results;
 
-                var selectFunc = context.Selector.Compile();
                 var results = QueryManager.ExecuteFindAll(
-                    () => FindAllQuery(context.Specification, context.QueryOptions).Select(selectFunc).ToList(),
+                    () => FindAllQuery(context.Specification, context.QueryOptions).Select(context.Selector).ToList(),
                     context.Specification,
                     context.Selector,
                     context.QueryOptions
@@ -633,7 +630,6 @@ namespace SharpRepository.Repository
                 if (!RunAspect(attribute => attribute.OnFindExecuting(context)))
                     return context.Result;
 
-                var selectFunc = context.Selector.Compile();
                 var item = QueryManager.ExecuteFind(
                     () =>
                         {
@@ -642,7 +638,7 @@ namespace SharpRepository.Repository
                                 return default(TResult);
 
                             var results = new[] { result };
-                            return results.AsEnumerable().Select(selectFunc).First();
+                            return results.AsQueryable().Select(context.Selector).First();
                         },
 
                     context.Specification,
@@ -795,18 +791,15 @@ namespace SharpRepository.Repository
 
         public virtual IEnumerable<TResult> GroupBy<TGroupKey, TResult>(ISpecification<T> criteria, Expression<Func<T, TGroupKey>> keySelector, Expression<Func<IGrouping<TGroupKey, T>, TResult>> resultSelector)
         {
-            var predicate = criteria?.Predicate?.Compile();
-            var keySelectFunc = keySelector.Compile();
-            var resultSelectFunc = resultSelector.Compile();
             return QueryManager.ExecuteGroup(
                 () =>
                 {
-                    var query = criteria == null ? BaseQuery() : BaseQuery().Where(predicate);
+                    var query = criteria == null ? BaseQuery() : BaseQuery().Where(criteria.Predicate);
 
                     //                            if (queryOptions != null)
                     //                                query = queryOptions.Apply(query);
 
-                    return query.GroupBy(keySelectFunc).OrderBy(x => x.Key).Select(resultSelectFunc).ToList();
+                    return query.GroupBy(keySelector).OrderBy(x => x.Key).Select(resultSelector).ToList();
                 },
                 keySelector,
                 resultSelector,
@@ -826,9 +819,8 @@ namespace SharpRepository.Repository
 
         public virtual long LongCount(ISpecification<T> criteria)
         {
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteLongCount(
-                () => criteria == null ? BaseQuery().LongCount() : BaseQuery().LongCount(predicate),
+                () => criteria == null ? BaseQuery().LongCount() : BaseQuery().LongCount(criteria.Predicate),
                 criteria
                 );
         }
@@ -845,9 +837,8 @@ namespace SharpRepository.Repository
 
         public virtual int Count(ISpecification<T> criteria)
         {
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteCount(
-                () => criteria == null ? BaseQuery().Count() : BaseQuery().Count(predicate),
+                () => criteria == null ? BaseQuery().Count() : BaseQuery().Count(criteria.Predicate),
                 criteria
                 );
         }
@@ -864,10 +855,8 @@ namespace SharpRepository.Repository
 
         public virtual int Sum(ISpecification<T> criteria, Expression<Func<T, int>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -885,10 +874,8 @@ namespace SharpRepository.Repository
 
         public virtual int? Sum(ISpecification<T> criteria, Expression<Func<T, int?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -906,10 +893,8 @@ namespace SharpRepository.Repository
 
         public virtual long Sum(ISpecification<T> criteria, Expression<Func<T, long>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -927,10 +912,8 @@ namespace SharpRepository.Repository
 
         public virtual long? Sum(ISpecification<T> criteria, Expression<Func<T, long?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -948,10 +931,8 @@ namespace SharpRepository.Repository
 
         public virtual decimal Sum(ISpecification<T> criteria, Expression<Func<T, decimal>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -969,10 +950,8 @@ namespace SharpRepository.Repository
 
         public virtual decimal? Sum(ISpecification<T> criteria, Expression<Func<T, decimal?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -990,10 +969,8 @@ namespace SharpRepository.Repository
 
         public virtual double Sum(ISpecification<T> criteria, Expression<Func<T, double>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -1011,10 +988,8 @@ namespace SharpRepository.Repository
 
         public virtual double? Sum(ISpecification<T> criteria, Expression<Func<T, double?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -1032,10 +1007,8 @@ namespace SharpRepository.Repository
 
         public virtual float Sum(ISpecification<T> criteria, Expression<Func<T, float>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -1053,10 +1026,8 @@ namespace SharpRepository.Repository
 
         public virtual float? Sum(ISpecification<T> criteria, Expression<Func<T, float?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteSum(
-                () => criteria == null ? BaseQuery().Sum(selectFunc) : BaseQuery().Where(predicate).Sum(selectFunc),
+                () => criteria == null ? BaseQuery().Sum(selector) : BaseQuery().Where(criteria.Predicate).Sum(selector),
                 selector,
                 criteria
                 );
@@ -1074,10 +1045,8 @@ namespace SharpRepository.Repository
 
         public virtual double Average(ISpecification<T> criteria, Expression<Func<T, int>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1095,10 +1064,8 @@ namespace SharpRepository.Repository
 
         public virtual double? Average(ISpecification<T> criteria, Expression<Func<T, int?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1116,10 +1083,8 @@ namespace SharpRepository.Repository
 
         public virtual double Average(ISpecification<T> criteria, Expression<Func<T, long>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1137,10 +1102,8 @@ namespace SharpRepository.Repository
 
         public virtual double? Average(ISpecification<T> criteria, Expression<Func<T, long?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1158,10 +1121,8 @@ namespace SharpRepository.Repository
 
         public virtual decimal Average(ISpecification<T> criteria, Expression<Func<T, decimal>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1179,10 +1140,8 @@ namespace SharpRepository.Repository
 
         public virtual decimal? Average(ISpecification<T> criteria, Expression<Func<T, decimal?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1200,10 +1159,8 @@ namespace SharpRepository.Repository
 
         public virtual double Average(ISpecification<T> criteria, Expression<Func<T, double>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1221,10 +1178,8 @@ namespace SharpRepository.Repository
 
         public virtual double? Average(ISpecification<T> criteria, Expression<Func<T, double?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1242,10 +1197,8 @@ namespace SharpRepository.Repository
 
         public virtual float Average(ISpecification<T> criteria, Expression<Func<T, float>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1263,10 +1216,8 @@ namespace SharpRepository.Repository
 
         public virtual float? Average(ISpecification<T> criteria, Expression<Func<T, float?>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteAverage(
-                () => criteria == null ? BaseQuery().Average(selectFunc) : BaseQuery().Where(predicate).Average(selectFunc),
+                () => criteria == null ? BaseQuery().Average(selector) : BaseQuery().Where(criteria.Predicate).Average(selector),
                 selector,
                 criteria
                 );
@@ -1284,10 +1235,8 @@ namespace SharpRepository.Repository
 
         public virtual TResult Min<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteMin(
-                () => criteria == null ? BaseQuery().Min(selectFunc) : BaseQuery().Where(predicate).Min(selectFunc),
+                () => criteria == null ? BaseQuery().Min(selector) : BaseQuery().Where(criteria.Predicate).Min(selector),
                 selector,
                 criteria
                 );
@@ -1305,10 +1254,8 @@ namespace SharpRepository.Repository
 
         public virtual TResult Max<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector)
         {
-            var selectFunc = selector.Compile();
-            var predicate = criteria?.Predicate?.Compile();
             return QueryManager.ExecuteMax(
-                () => criteria == null ? BaseQuery().Max(selectFunc) : BaseQuery().Where(predicate).Max(selectFunc),
+                () => criteria == null ? BaseQuery().Max(selector) : BaseQuery().Where(criteria.Predicate).Max(selector),
                 selector,
                 criteria
                 );

--- a/SharpRepository.Repository/RepositoryBase.cs
+++ b/SharpRepository.Repository/RepositoryBase.cs
@@ -282,7 +282,7 @@ namespace SharpRepository.Repository
                     context.Specification.FetchStrategy = fetchStrategy;
 
                     results = QueryManager.ExecuteFindAll(
-                        () => FindAllQuery(context.Specification, context.QueryOptions).Select(selectFunc).ToList(),
+                        () => FindAllQuery(context.Specification, context.QueryOptions).Select(context.Selector).ToList(),
                         context.Specification,
                         context.Selector,
                         context.QueryOptions


### PR DESCRIPTION
Fix for bug #207 

Revert change that was found by @neman. I haven't investigated it much yet, but all unit tests run fine, and I can't remember why I made that change as part of making the library .NET Standard compatible. Integration tests have not been executed before making this PR.