### PR TITLE
Get and Find select before query, even in mongodb

### DIFF
--- a/SharpRepository.Benchmarks.Configuration/SharpRepository.Benchmarks.Configuration.csproj
+++ b/SharpRepository.Benchmarks.Configuration/SharpRepository.Benchmarks.Configuration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net461</TargetFrameworks>
 	  <Authors>Ben Griswold, Jeff Treuting</Authors>
     <Description>SharpRepository performance test</Description>
     <Summary>Written in C#, includes support for various relational, document and object databases including Entity Framework, RavenDB, MongoDB, CouchDB and Db4o. SharpRepository includes Xml and InMemory repository implementations as well. SharpRepository offers built-in caching options for AppFabric, memcached and the standard System.Runtime.Caching. SharpRepository also supports Specifications, FetchStrategies, Batches and Traits!</Summary>

--- a/SharpRepository.EfCoreRepository/EfCoreRepositoryBase.cs
+++ b/SharpRepository.EfCoreRepository/EfCoreRepositoryBase.cs
@@ -55,9 +55,8 @@ namespace SharpRepository.EfCoreRepository
             {
                 if (entry.State == EntityState.Detached)
                 {
-                    TKey key;
 
-                    if (GetPrimaryKey(entity, out key))
+                    if (GetPrimaryKey(entity, out TKey key))
                     {
                         // check to see if this item is already attached
                         //  if it is then we need to copy the values to the attached value instead of changing the State to modified since it will throw a duplicate key exception
@@ -93,7 +92,7 @@ namespace SharpRepository.EfCoreRepository
         }
 
         // we override the implementation fro LinqBaseRepository becausee this is built in and doesn't need to find the key column and do dynamic expressions, etc.
-        //  this also provides the EF5 first level caching out of the box
+        // this also provides the EF5 first level caching out of the box
         protected override T GetQuery(TKey key, IFetchStrategy<T> fetchStrategy)
         {
             return fetchStrategy == null ? DbSet.Find(key) : base.GetQuery(key, fetchStrategy);

--- a/SharpRepository.InMemoryRepository/SharpRepository.InMemoryRepository.csproj
+++ b/SharpRepository.InMemoryRepository/SharpRepository.InMemoryRepository.csproj
@@ -14,7 +14,7 @@
 	  <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/SharpRepository/SharpRepository.git</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>
-	  <Version>2.0.1-beta1</Version>
+	  <Version>2.0.3</Version>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />

--- a/SharpRepository.Ioc.Mvc/SharpRepository.Ioc.Mvc.csproj
+++ b/SharpRepository.Ioc.Mvc/SharpRepository.Ioc.Mvc.csproj
@@ -5,8 +5,8 @@
     <Description>Injects SharpRepository using StructureMap in your Asp.Net Mvc 5 and WebApi 2 project</Description>
     <Summary>Written in C#, includes support for various relational, document and object databases including Entity Framework, RavenDB, MongoDB, CouchDB and Db4o. SharpRepository includes Xml and InMemory repository implementations as well. SharpRepository offers built-in caching options for AppFabric, memcached and the standard System.Runtime.Caching. SharpRepository also supports Specifications, FetchStrategies, Batches and Traits!</Summary>
 	  <PackageId>SharpRepository.Ioc.Mvc</PackageId>
-    <PackageVersion>2.0.3</PackageVersion>
-	  <PackageReleaseNotes>2.0.3: stable release</PackageReleaseNotes>
+    <PackageVersion>2.0.3.1-prerelease</PackageVersion>
+	  <PackageReleaseNotes>2.0.3.1: updated package versions</PackageReleaseNotes>
 	  <PackageTags>SharpRepository Repository IoC Mvc Mvc5 AspNet WebApi</PackageTags>
 	  <PackageIconUrl>https://user-images.githubusercontent.com/6349515/28491142-7b6350c4-6eeb-11e7-9c5b-e3b8ef1e73b8.png</PackageIconUrl>
 	  <PackageProjectUrl>https://github.com/SharpRepository/SharpRepository</PackageProjectUrl>

--- a/SharpRepository.MongoDbRepository/MongoDbRepositoryBase.cs
+++ b/SharpRepository.MongoDbRepository/MongoDbRepositoryBase.cs
@@ -144,6 +144,20 @@ namespace SharpRepository.MongoDbRepository
             else return default(T);
         }
 
+        protected override TResult GetQuery<TResult>(TKey key, IFetchStrategy<T> fetchStrategy, Expression<Func<T, TResult>> selector)
+        {
+            var keyBsonType = ((StringSerializer)BsonClassMap.LookupClassMap(typeof(T)).IdMemberMap.GetSerializer()).Representation;
+            var keyMemberName = BsonClassMap.LookupClassMap(typeof(T)).IdMemberMap.MemberName;
+            if (IsValidKey(key))
+            {
+                var keyBsonValue = BsonTypeMapper.MapToBsonValue(key, keyBsonType);
+                var filter = Builders<T>.Filter.Eq(keyMemberName, keyBsonValue);
+                return BaseCollection().Find(filter).Project(selector).FirstOrDefault();
+            }
+            else return default(TResult);
+        }
+
+
         #region Math
         public override int Sum(ISpecification<T> criteria, Expression<Func<T, int>> selector)
         {

--- a/SharpRepository.MongoDbRepository/SharpRepository.MongoDbRepository.csproj
+++ b/SharpRepository.MongoDbRepository/SharpRepository.MongoDbRepository.csproj
@@ -5,7 +5,7 @@
     <Description>SharpRepository generic repository implemented in MongoDb</Description>
     <Summary>Written in C#, includes support for various relational, document and object databases including Entity Framework, RavenDB, MongoDB, CouchDB and Db4o. SharpRepository includes Xml and InMemory repository implementations as well. SharpRepository offers built-in caching options for AppFabric, memcached and the standard System.Runtime.Caching. SharpRepository also supports Specifications, FetchStrategies, Batches and Traits!</Summary>
 	  <PackageId>SharpRepository.MongoDbRepository</PackageId>
-    <PackageVersion>2.0.7.1-beta1</PackageVersion>
+    <PackageVersion>2.0.7.2-prerelease</PackageVersion>
 	  <PackageReleaseNotes>2.0.7: addeded MongoDbCollectionNameAttribute that allows to change collection name, update mongo driver to 2.7.0</PackageReleaseNotes>
 	  <PackageTags>SharpRepository Repository MongoDbRepository MongoDb Mongo</PackageTags>
 	  <PackageIconUrl>https://user-images.githubusercontent.com/6349515/28491142-7b6350c4-6eeb-11e7-9c5b-e3b8ef1e73b8.png</PackageIconUrl>

--- a/SharpRepository.Repository/Caching/ICachingStrategy.cs
+++ b/SharpRepository.Repository/Caching/ICachingStrategy.cs
@@ -12,6 +12,9 @@ namespace SharpRepository.Repository.Caching
         bool TryGetResult(TKey key, out T result);
         void SaveGetResult(TKey key, T result);
 
+        bool TryGetResult<TResult>(TKey key, Expression<Func<T, TResult>> selector, out TResult result);
+        void SaveGetResult<TResult>(TKey key, Expression<Func<T, TResult>> selector, TResult result);
+
         bool TryGetAllResult<TResult>(IQueryOptions<T> queryOptions, Expression<Func<T, TResult>> selector, out IEnumerable<TResult> result);
         void SaveGetAllResult<TResult>(IQueryOptions<T> queryOptions, Expression<Func<T, TResult>> selector, IEnumerable<TResult> result);
 

--- a/SharpRepository.Repository/Caching/NoCachingStrategyBase.cs
+++ b/SharpRepository.Repository/Caching/NoCachingStrategyBase.cs
@@ -24,6 +24,17 @@ namespace SharpRepository.Repository.Caching
 
         }
 
+        public bool TryGetResult<TResult>(TKey key, Expression<Func<T, TResult>> selector, out TResult result)
+        {
+            result = default(TResult);
+            return false;
+        }
+
+        public void SaveGetResult<TResult>(TKey key, Expression<Func<T, TResult>> selector, TResult result)
+        {
+
+        }
+        
         public bool TryGetAllResult<TResult>(IQueryOptions<T> queryOptions, Expression<Func<T, TResult>> selector, out IEnumerable<TResult> result)
         {
             result = default(IEnumerable<TResult>);

--- a/SharpRepository.Repository/LinqRepositoryBase.cs
+++ b/SharpRepository.Repository/LinqRepositoryBase.cs
@@ -26,6 +26,11 @@ namespace SharpRepository.Repository
             return FindQuery(ByPrimaryKeySpecification(key, fetchStrategy));
         }
 
+        protected override TResult GetQuery<TResult>(TKey key, IFetchStrategy<T> fetchStrategy, Expression<Func<T, TResult>> selector)
+        {
+            return FindQuery(ByPrimaryKeySpecification(key, fetchStrategy), selector);
+        }
+
         protected override T FindQuery(ISpecification<T> criteria)
         {
             var query = BaseQuery(criteria.FetchStrategy);
@@ -34,6 +39,16 @@ namespace SharpRepository.Repository
 
             return criteria.SatisfyingEntityFrom(query);
         }
+
+        protected TResult FindQuery<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector)
+        {
+            var query = BaseQuery(criteria.FetchStrategy);
+
+            SetTraceInfo("Find", query);
+
+            return criteria.SatisfyingEntitiesFrom(query).Select(selector).FirstOrDefault();
+        }
+
 
         protected override T FindQuery(ISpecification<T> criteria, IQueryOptions<T> queryOptions)
         {
@@ -46,6 +61,19 @@ namespace SharpRepository.Repository
 
             return criteria.SatisfyingEntityFrom(query);
         }
+        
+        protected override TResult FindQuery<TResult>(ISpecification<T> criteria, Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions)
+        {
+            if (queryOptions == null)
+                return FindQuery(criteria, selector);
+
+            var query = queryOptions.Apply(BaseQuery(criteria.FetchStrategy));
+
+            SetTraceInfo("Find", query);
+
+            return criteria.SatisfyingEntitiesFrom(query).Select(selector).FirstOrDefault();
+        }
+
 
         protected override IQueryable<T> GetAllQuery(IFetchStrategy<T> fetchStrategy)
         {

--- a/SharpRepository.Repository/Queries/QueryManager.cs
+++ b/SharpRepository.Repository/Queries/QueryManager.cs
@@ -44,6 +44,23 @@ namespace SharpRepository.Repository.Queries
             return result;
         }
 
+        public TResult ExecuteGet<TResult>(Func<TResult> query, TKey key, Expression<Func<T, TResult>> selector)
+        {
+            if (CacheEnabled && _cachingStrategy.TryGetResult(key, selector, out TResult result))
+            {
+                CacheUsed = true;
+                return result;
+            }
+
+            CacheUsed = false;
+
+            result = query.Invoke();
+
+            _cachingStrategy.SaveGetResult(key, selector,  result);
+
+            return result;
+        }
+
         public IEnumerable<TResult> ExecuteGetAll<TResult>(Func<IEnumerable<TResult>> query, Expression<Func<T, TResult>> selector, IQueryOptions<T> queryOptions)
         {
             if (CacheEnabled && _cachingStrategy.TryGetAllResult(queryOptions, selector, out IEnumerable<TResult> result))

--- a/SharpRepository.Samples.CoreMvc/SharpRepository.Samples.CoreMvc.csproj
+++ b/SharpRepository.Samples.CoreMvc/SharpRepository.Samples.CoreMvc.csproj
@@ -1,17 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpRepository.Tests.Integration/Spikes/StandardCachingSpikes.cs
+++ b/SharpRepository.Tests.Integration/Spikes/StandardCachingSpikes.cs
@@ -113,13 +113,13 @@ namespace SharpRepository.Tests.Integration.Spikes
 
             const string contactId = "1";
 
-            var contactName = repository.Get(contactId, c => c.Name);
-            contactName.ShouldBe("Contact 1");
-
             var contact = repository.Get(contactId);
-            contact.Name = "Contact 1 - EDITED";
+            contact.Name.ShouldBe("Contact 1");
 
-            contactName = repository.Get(contactId, c => c.Name);
+            var contact2 = repository.Get(contactId);
+            contact2.Name = "Contact 1 - EDITED";
+
+            var contactName = repository.Get(contactId, c => c.Name);
             contactName.ShouldBe("Contact 1 - EDITED");
         }
 

--- a/SharpRepository.Tests/Caching/ClearCacheTests.cs
+++ b/SharpRepository.Tests/Caching/ClearCacheTests.cs
@@ -22,6 +22,8 @@ namespace SharpRepository.Tests.Caching
         [Test]
         public void ClearAllCache_Throws_Exception_WIthout_OutOfBox()
         {
+            Cache.CachePrefixManager = null; //static class come around tests if order change
+
             try
             {
                 Cache.ClearAll();

--- a/SharpRepository.Tests/Caching/InMemoryCachingTests.cs
+++ b/SharpRepository.Tests/Caching/InMemoryCachingTests.cs
@@ -131,7 +131,7 @@ namespace SharpRepository.Tests.Caching
         }
 
         [Test]
-        public void ExecuteGet_With_Selector_Should_Use_Cache_After_First_Call()
+        public void ExecuteGet_With_Selector_Should_Be_Cached_After_Use()
         {
             var repos = new InMemoryRepository<Contact>(new StandardCachingStrategy<Contact>(cacheProvider));
 
@@ -139,8 +139,12 @@ namespace SharpRepository.Tests.Caching
             repos.Add(new Contact { Name = "Test2" });
 
             var item = repos.Get(1, x => x.Name);
+            repos.CacheUsed.ShouldBeFalse();
+            item.ShouldBe("Test1");
+
+            var itemSecondRead = repos.Get(1, x => x.Name);
             repos.CacheUsed.ShouldBeTrue();
-            item.ShouldNotBeNull();
+            item.ShouldBe("Test1");
         }
 
         [Test]


### PR DESCRIPTION
I need to change some behavior in cache if projection is made from database even in Get and Find methods.

It's impossible now, to use cache updated entity with an Add() to read all projections from this.
https://github.com/SharpRepository/SharpRepository/compare/Feature/selectBeforeQuery?expand=1#diff-e2e231050a29228dacbea434ae581426R142

And it's impossible to cache a full entity if I make a projection directly on query
https://github.com/SharpRepository/SharpRepository/compare/Feature/selectBeforeQuery?expand=1#diff-36595eacb8ef99061bc3c5e4a2a8d030L116