### PR TITLE
AsNoTracking

### DIFF
--- a/SharpRepository.EfCoreRepository/EfCoreCompoundKeyRepositoryBase.cs
+++ b/SharpRepository.EfCoreRepository/EfCoreCompoundKeyRepositoryBase.cs
@@ -70,6 +70,11 @@ namespace SharpRepository.EfCoreRepository
         {
             var query = DbSet.AsQueryable();
 
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }
 
@@ -158,6 +163,11 @@ namespace SharpRepository.EfCoreRepository
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)
         {
             var query = DbSet.AsQueryable();
+
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
 
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }

--- a/SharpRepository.EfCoreRepository/EfCoreCompoundKeyRepositoryBase.cs
+++ b/SharpRepository.EfCoreRepository/EfCoreCompoundKeyRepositoryBase.cs
@@ -70,7 +70,7 @@ namespace SharpRepository.EfCoreRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }
@@ -164,7 +164,7 @@ namespace SharpRepository.EfCoreRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }

--- a/SharpRepository.EfCoreRepository/EfCoreRepositoryBase.cs
+++ b/SharpRepository.EfCoreRepository/EfCoreRepositoryBase.cs
@@ -88,6 +88,11 @@ namespace SharpRepository.EfCoreRepository
         {
             var query = DbSet.AsQueryable();
 
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }
 

--- a/SharpRepository.EfCoreRepository/EfCoreRepositoryBase.cs
+++ b/SharpRepository.EfCoreRepository/EfCoreRepositoryBase.cs
@@ -88,7 +88,7 @@ namespace SharpRepository.EfCoreRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }

--- a/SharpRepository.EfCoreRepository/SharpRepository.EfCoreRepository.csproj
+++ b/SharpRepository.EfCoreRepository/SharpRepository.EfCoreRepository.csproj
@@ -5,8 +5,8 @@
     <Description>SharpRepository generic repository implementation for Entity Framework 1.1 and 2</Description>
     <Summary>Written in C#, includes support for various relational, document and object databases including Entity Framework, RavenDB, MongoDB, CouchDB and Db4o. SharpRepository includes Xml and InMemory repository implementations as well. SharpRepository offers built-in caching options for AppFabric, memcached and the standard System.Runtime.Caching. SharpRepository also supports Specifications, FetchStrategies, Batches and Traits!</Summary>
 	  <PackageId>SharpRepository.EfCoreRepository</PackageId>
-    <PackageVersion>2.1.0-prerelease</PackageVersion>
-	  <PackageReleaseNotes>2.1.0: Support for EFCore 3.0</PackageReleaseNotes>
+    <PackageVersion>2.1.1-prerelease</PackageVersion>
+	  <PackageReleaseNotes>2.1: Support for EFCore 3.0, AsNoTracking fetch strategy</PackageReleaseNotes>
 	  <PackageTags>SharpRepository Repository EfCoreRepository EntityFrameworkCore Entity Framework Core 2</PackageTags>
 	  <PackageIconUrl>https://user-images.githubusercontent.com/6349515/28491142-7b6350c4-6eeb-11e7-9c5b-e3b8ef1e73b8.png</PackageIconUrl>
 	  <PackageProjectUrl>https://github.com/SharpRepository/SharpRepository</PackageProjectUrl>
@@ -14,7 +14,7 @@
 	  <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/SharpRepository/SharpRepository.git</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>
-	  <Version>2.1.0</Version>
+	  <Version>2.1.1</Version>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.6" />

--- a/SharpRepository.EfRepository/EfCompoundKeyRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfCompoundKeyRepositoryBase.cs
@@ -70,6 +70,12 @@ namespace SharpRepository.EfRepository
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)
         {
             var query = DbSet.AsQueryable();
+
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }
 
@@ -158,6 +164,12 @@ namespace SharpRepository.EfRepository
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)
         {
             var query = DbSet.AsQueryable();
+
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }
 
@@ -247,6 +259,12 @@ namespace SharpRepository.EfRepository
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)
         {
             var query = DbSet.AsQueryable();
+
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }
 

--- a/SharpRepository.EfRepository/EfCompoundKeyRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfCompoundKeyRepositoryBase.cs
@@ -71,7 +71,7 @@ namespace SharpRepository.EfRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }
@@ -165,7 +165,7 @@ namespace SharpRepository.EfRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }
@@ -260,7 +260,7 @@ namespace SharpRepository.EfRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }

--- a/SharpRepository.EfRepository/EfRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfRepositoryBase.cs
@@ -102,7 +102,7 @@ namespace SharpRepository.EfRepository
         {
             var query = DbSet.AsQueryable();
 
-            if (fetchStrategy.NoTracking)
+            if (fetchStrategy != null && fetchStrategy.NoTracking)
             {
                 query = query.AsNoTracking();
             }

--- a/SharpRepository.EfRepository/EfRepositoryBase.cs
+++ b/SharpRepository.EfRepository/EfRepositoryBase.cs
@@ -101,6 +101,12 @@ namespace SharpRepository.EfRepository
         protected override IQueryable<T> BaseQuery(IFetchStrategy<T> fetchStrategy = null)
         {
             var query = DbSet.AsQueryable();
+
+            if (fetchStrategy.NoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
             return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
         }
 

--- a/SharpRepository.EfRepository/SharpRepository.EfRepository.csproj
+++ b/SharpRepository.EfRepository/SharpRepository.EfRepository.csproj
@@ -6,8 +6,8 @@
     <Description>SharpRepository generic repository implemented with Entity Framework 6</Description>
     <Summary>Written in C#, includes support for various relational, document and object databases including Entity Framework, RavenDB, MongoDB, CouchDB and Db4o. SharpRepository includes Xml and InMemory repository implementations as well. SharpRepository offers built-in caching options for AppFabric, memcached and the standard System.Runtime.Caching. SharpRepository also supports Specifications, FetchStrategies, Batches and Traits!</Summary>
 	  <PackageId>SharpRepository.EfRepository</PackageId>
-    <PackageVersion>2.1.0-prerelease</PackageVersion>
-	  <PackageReleaseNotes>2.1.0: update to EF6.3 that supports Core 3, compatibilty with generic dependency resolver</PackageReleaseNotes>
+    <PackageVersion>2.1.1-prerelease</PackageVersion>
+	  <PackageReleaseNotes>2.1: update to EF6.3 that supports Core 3, compatibilty with generic dependency resolver, AsNoTracking fetch strategy</PackageReleaseNotes>
 	  <PackageTags>SharpRepository Repository EfRepository EntityFramework Entity Framework EF6</PackageTags>
 	  <PackageIconUrl>https://user-images.githubusercontent.com/6349515/28491142-7b6350c4-6eeb-11e7-9c5b-e3b8ef1e73b8.png</PackageIconUrl>
 	  <PackageProjectUrl>https://github.com/SharpRepository/SharpRepository</PackageProjectUrl>
@@ -15,7 +15,7 @@
 	  <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/SharpRepository/SharpRepository.git</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>
-	  <Version>2.1.0</Version>
+	  <Version>2.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SharpRepository.Repository/FetchStrategies/AbstractFetchStrategy.cs
+++ b/SharpRepository.Repository/FetchStrategies/AbstractFetchStrategy.cs
@@ -7,14 +7,19 @@ namespace SharpRepository.Repository.FetchStrategies
     public abstract class AbstractFetchStrategy<T> : IFetchStrategy<T>
     {
         public abstract IEnumerable<string> IncludePaths { get; }
+
+        public abstract bool NoTracking { get; }
+
+        public abstract IFetchStrategy<T> AsNoTracking();        
+
         public abstract IFetchStrategy<T> Include(Expression<Func<T, object>> path);
         public abstract IFetchStrategy<T> Include(string path);
 
         public override string ToString()
         {
-            return String.Format("Type: {0} Includes: {1}",
+            return string.Format("Type: {0} Includes: {1}",
                     GetType().Name,
-                    String.Join(",", IncludePaths)
+                    string.Join(",", IncludePaths)
                 );
         }
     }

--- a/SharpRepository.Repository/FetchStrategies/GenericFetchStrategy.cs
+++ b/SharpRepository.Repository/FetchStrategies/GenericFetchStrategy.cs
@@ -12,15 +12,31 @@ namespace SharpRepository.Repository.FetchStrategies
     public class GenericFetchStrategy<T> : AbstractFetchStrategy<T>
     {
         private readonly IList<string> _properties;
+        private bool _noTracking;
 
         public GenericFetchStrategy()
         {
             _properties = new List<string>();
+            _noTracking = false;
         }
 
         public override IEnumerable<string> IncludePaths
         {
             get { return _properties; }
+        }
+
+        public override bool NoTracking
+        {
+            get { return _noTracking; }
+        }
+
+
+
+        public override IFetchStrategy<T> AsNoTracking()
+        {
+            _noTracking = true;
+
+            return this;
         }
 
         public override IFetchStrategy<T> Include(Expression<Func<T, object>> path)

--- a/SharpRepository.Repository/FetchStrategies/IFetchStrategy.cs
+++ b/SharpRepository.Repository/FetchStrategies/IFetchStrategy.cs
@@ -13,8 +13,12 @@ namespace SharpRepository.Repository.FetchStrategies
     {
         IEnumerable<string> IncludePaths { get; }
 
+        bool NoTracking { get; }
+
         IFetchStrategy<T> Include(Expression<Func<T, object>> path);
 
         IFetchStrategy<T> Include(string path);
+
+        IFetchStrategy<T> AsNoTracking();
     }
 }

--- a/SharpRepository.Repository/SharpRepository.Repository.csproj
+++ b/SharpRepository.Repository/SharpRepository.Repository.csproj
@@ -5,8 +5,8 @@
     <Description>SharpRepository is a generic repository library</Description>
     <Summary>Written in C#, includes support for various relational, document and object databases including Entity Framework, RavenDB, MongoDB, CouchDB and Db4o. SharpRepository includes Xml and InMemory repository implementations as well. SharpRepository offers built-in caching options for AppFabric, memcached and the standard System.Runtime.Caching. SharpRepository also supports Specifications, FetchStrategies, Batches and Traits!</Summary>
 	  <PackageId>SharpRepository.Repository</PackageId>
-    <PackageVersion>2.1.0-prerelease</PackageVersion>
-	  <PackageReleaseNotes>2.1.0: DependencyResolver uses System.IServiceProvider</PackageReleaseNotes>
+    <PackageVersion>2.1.1-prerelease</PackageVersion>
+	  <PackageReleaseNotes>2.1: DependencyResolver uses System.IServiceProvider, add AsNoTracking fetch strategy</PackageReleaseNotes>
 	  <PackageTags>SharpRepository Repository</PackageTags>
 	  <PackageIconUrl>https://user-images.githubusercontent.com/6349515/28491142-7b6350c4-6eeb-11e7-9c5b-e3b8ef1e73b8.png</PackageIconUrl>
 	  <PackageProjectUrl>https://github.com/SharpRepository/SharpRepository</PackageProjectUrl>
@@ -14,7 +14,7 @@
 	  <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/SharpRepository/SharpRepository.git</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>
-	  <Version>2.1.0</Version>
+	  <Version>2.1.1</Version>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />

--- a/SharpRepository.Tests.Integration/Spikes/EfAsNoTracking.cs
+++ b/SharpRepository.Tests.Integration/Spikes/EfAsNoTracking.cs
@@ -1,0 +1,120 @@
+﻿using System.Data.Entity;
+using System.Linq;
+using NUnit.Framework;
+using SharpRepository.EfRepository;
+using SharpRepository.Tests.Integration.Data;
+using SharpRepository.Tests.Integration.TestObjects;
+using System.Collections.Generic;
+using Shouldly;
+using SharpRepository.Repository.FetchStrategies;
+
+namespace SharpRepository.Tests.Integration.Spikes
+{
+    [TestFixture]
+    public class EfAsNoTracking
+    {
+        private TestObjectContext dbContext;
+
+        [SetUp]
+        public void SetupRepository()
+        {
+            var dbPath = EfDataDirectoryFactory.Build();
+            dbContext = new TestObjectContext("Data Source=" + dbPath);
+
+            const int totalItems = 5;
+
+            for (int i = 1; i <= totalItems; i++)
+            {
+                dbContext.Contacts.Add(
+                    new Contact
+                    {
+                        ContactId = i.ToString(),
+                        Name = "Test User " + i,
+                        EmailAddresses = new List<EmailAddress> {
+                            new EmailAddress {
+                                ContactId = i.ToString(),
+                                EmailAddressId = i,
+                                Email = "omar.piani." + i.ToString() + "@email.com",
+                                Label = "omar.piani." + i.ToString()
+                            }
+                        }
+                    });
+            }
+
+            dbContext.SaveChanges();
+
+            // reistantiate in order to lose caches
+            dbContext = new TestObjectContext("Data Source=" + dbPath);
+        }
+
+        [Test]
+        public void GetAllSateShouldBeUnchanged()
+        {
+            var repository = new EfRepository<Contact, string>(dbContext);
+
+            var firstContact = repository.GetAll().First();
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void GetAllWithStrategySateShouldBeUnchanged()
+        {
+            var repository = new EfRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>();
+
+            var firstContact = repository.GetAll(strat).First();
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void GetAllWithStrategyAsNoTrackingSateShouldBeUnchanged()
+        {
+            var repository = new EfRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>()
+                .AsNoTracking();
+
+            var firstContact = repository.GetAll(strat).First();
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Detached);
+        }
+
+        [Test]
+        public void GetSateShouldBeUnchanged()
+        {
+            var repository = new EfRepository<Contact, string>(dbContext);
+
+            var firstContact = repository.Get("1");
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void GetWithStrategySateShouldBeUnchanged()
+        {
+            var repository = new EfRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>();
+
+            var firstContact = repository.Get("1", strat);
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void GetWithStrategyAsNoTrackingSateShouldBeUnchanged()
+        {
+            var repository = new EfRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>()
+                .AsNoTracking();
+
+            var firstContact = repository.Get("1", strat);
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Detached);
+        }
+    }
+}

--- a/SharpRepository.Tests.Integration/Spikes/EfCoreAsNoTracking.cs
+++ b/SharpRepository.Tests.Integration/Spikes/EfCoreAsNoTracking.cs
@@ -1,0 +1,132 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SharpRepository.EfCoreRepository;
+using SharpRepository.Tests.Integration.Data;
+using SharpRepository.Tests.Integration.TestObjects;
+using System.Collections.Generic;
+using Shouldly;
+using SharpRepository.Repository.FetchStrategies;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace SharpRepository.Tests.Integration.Spikes
+{
+    [TestFixture]
+    public class EfCoreAsNoTracking
+    {
+        private TestObjectContextCore dbContext;
+
+        [SetUp]
+        public void SetupRepository()
+        {
+            var dbPath = EfDataDirectoryFactory.Build();
+
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            var options = new DbContextOptionsBuilder<TestObjectContextCore>()
+                 .UseSqlite(connection)
+                 .Options;
+
+            using (dbContext = new TestObjectContextCore(options))
+            {
+                dbContext.Database.EnsureCreated();
+
+                const int totalItems = 5;
+
+                for (int i = 1; i <= totalItems; i++)
+                {
+                    dbContext.Contacts.Add(
+                        new Contact
+                        {
+                            ContactId = i.ToString(),
+                            Name = "Test User " + i,
+                            EmailAddresses = new List<EmailAddress> {
+                            new EmailAddress {
+                                ContactId = i.ToString(),
+                                EmailAddressId = i,
+                                Email = "omar.piani." + i.ToString() + "@email.com",
+                                Label = "omar.piani." + i.ToString()
+                            }
+                            }
+                        });
+                }
+
+                dbContext.SaveChanges();
+            }
+
+            // reistantiate in order to lose caches
+            dbContext = new TestObjectContextCore(options);
+        }
+
+        [Test]
+        public void EfCoreGetAllSateShouldBeUnchanged()
+        {
+            var repository = new EfCoreRepository<Contact, string>(dbContext);
+
+            var firstContact = repository.GetAll().First();
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void EfCoreGetAllWithStrategySateShouldBeUnchanged()
+        {
+            var repository = new EfCoreRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>();
+
+            var firstContact = repository.GetAll(strat).First();
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void EfCoreGetAllWithStrategyAsNoTrackingSateShouldBeUnchanged()
+        {
+            var repository = new EfCoreRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>()
+                .AsNoTracking();
+
+            var firstContact = repository.GetAll(strat).First();
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Detached);
+        }
+
+        [Test]
+        public void EfCoreGetSateShouldBeUnchanged()
+        {
+            var repository = new EfCoreRepository<Contact, string>(dbContext);
+
+            var firstContact = repository.Get("1");
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void EfCoreGetWithStrategySateShouldBeUnchanged()
+        {
+            var repository = new EfCoreRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>();
+
+            var firstContact = repository.Get("1", strat);
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Unchanged);
+        }
+
+        [Test]
+        public void EfCoreGetWithStrategyAsNoTrackingSateShouldBeUnchanged()
+        {
+            var repository = new EfCoreRepository<Contact, string>(dbContext);
+
+            var strat = new GenericFetchStrategy<Contact>()
+                .AsNoTracking();
+
+            var firstContact = repository.Get("1", strat);
+
+            dbContext.Entry(firstContact).State.ShouldBe(EntityState.Detached);
+        }
+    }
+}

--- a/SharpRepository.Tests/FetchStrategies/FetchStrategyTests.cs
+++ b/SharpRepository.Tests/FetchStrategies/FetchStrategyTests.cs
@@ -53,5 +53,21 @@ namespace SharpRepository.Tests.FetchStrategies
 
             strategy.IncludePaths.ShouldContain("EmailAddresses.Email");
         }
+
+        [Test]
+        public void FetchStrategy_AsNoTracking_Default_Is_False()
+        {
+            new GenericFetchStrategy<Contact>()
+                .NoTracking.ShouldBeFalse();
+        }
+
+        [Test]
+        public void FetchStrategy_AsNoTracking_Set_AsNoTracking()
+        {
+            var strategy = new GenericFetchStrategy<Contact>().AsNoTracking();
+
+            strategy.NoTracking.ShouldBeTrue();
+        }
+
     }
 }


### PR DESCRIPTION
I added the possibility to use EF and EFCore [AsNoTracking](https://docs.microsoft.com/it-it/ef/core/querying/tracking) 
```
var strat = new GenericFetchStrategy<Contact>()
                .AsNoTracking();

var firstContact = repository.Get("1", strat);
```

I hope I didn't break any pattern, but near "include" methods seems the better place!